### PR TITLE
raise video import limit to 800 MiB

### DIFF
--- a/docs/media-contract.md
+++ b/docs/media-contract.md
@@ -57,7 +57,7 @@ Rules:
 | Extension | `.mp4` only |
 | Type | regular file after `lstat` + `realpath` |
 | Symlink / reparse | rejected |
-| Size | `1 byte … 500 MiB` |
+| Size | `1 byte … 800 MiB` |
 | Container | first ISO-BMFF box size sane and type `ftyp` |
 | Companion image | required |
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,7 +3,7 @@ export const SCHEMA_ID = "beauticode.background/v1" as const;
 // Images are embedded into one CDP Runtime.evaluate payload. Keep validation
 // and injection limits identical so an accepted import is always publishable.
 export const MAX_IMAGE_BYTES = 18 * 1024 * 1024;
-export const MAX_VIDEO_BYTES = 500 * 1024 * 1024;
+export const MAX_VIDEO_BYTES = 800 * 1024 * 1024;
 
 /**
  * Max raw media bytes embedded as a data: URL inside one CDP evaluate.

--- a/packages/core/test/media-validation.test.js
+++ b/packages/core/test/media-validation.test.js
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { MAX_VIDEO_BYTES } from "../dist/constants.js";
 import {
   assertSafeBasename,
   isMp4Container,
@@ -71,6 +72,23 @@ test("validateVideoFile enforces extension, size, ftyp, no symlink", async () =>
     await assert.rejects(
       () => validateVideoFile(path.join(linkedRoot, "background.mp4")),
       /symbolic link|reparse point/,
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("validateVideoFile defaults to an 800 MiB limit", async () => {
+  assert.equal(MAX_VIDEO_BYTES, 800 * 1024 * 1024);
+
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bc-video-limit-"));
+  try {
+    const oversized = path.join(root, "oversized.mp4");
+    await fs.writeFile(oversized, mp4Fixture());
+    await fs.truncate(oversized, MAX_VIDEO_BYTES + 1);
+    await assert.rejects(
+      () => validateVideoFile(oversized),
+      /no larger than 838860800 bytes/,
     );
   } finally {
     await fs.rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## What changed

- raise the default MP4 import limit from 500 MiB to 800 MiB
- update the media contract documentation
- add a regression test for the configured limit and oversized-file rejection

## Why

Users can import larger local background videos without changing the existing streaming, validation, or saved-theme storage behavior.

## Impact

Accepted MP4 files may now be up to 800 MiB. The 2 GiB saved-theme storage quota remains unchanged.

## Validation

- `npm test` (43 tests passed)
- `npm run typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 视频文件大小上限从 500 MiB 提升至 800 MiB，支持处理更大的视频文件。

* **文档**
  * 更新视频验证规则，明确记录新的 800 MiB 文件大小上限。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->