### PR TITLE
release v0.1.2 with black-edge and ChatGPT matching fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           $scripts = @(
             "apps/tray/start-tray.ps1",
+            "scripts/codex-launch.ps1",
             "scripts/start-beauticode-engine.ps1",
             "scripts/install-desktop-shortcut.ps1",
             "scripts/build-windows-installer.ps1"

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ beautiCode 可以让你：
 > 不是逃离工作，而是给漫长的工作过程，留一点属于自己的空间。
 <img width="1920" height="1240" alt="QQ20260729-212506-HD" src="https://github.com/user-attachments/assets/ca0ef07f-2aec-46b0-b996-1db9913efa6d" />
 
-### v0.1.1 安装包
+### v0.1.2 安装包
 
-想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.1)。
+想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.2)。
 安装包自带运行时，不需要另外安装 Node.js 或 npm；使用前请先安装 Codex Desktop。
 
 
@@ -163,7 +163,7 @@ Ctrl + Shift + Space
 运行：
 
 ```text
-beautiCode-Setup-0.1.1-win-x64.exe
+beautiCode-Setup-0.1.2-win-x64.exe
 ```
 
 安装包自带 Node.js 运行时。使用者不需要安装 Node.js、npm，也不需要保留

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ beautiCode 可以让你：
 > 不是逃离工作，而是给漫长的工作过程，留一点属于自己的空间。
 <img width="1920" height="1240" alt="QQ20260729-212506-HD" src="https://github.com/user-attachments/assets/ca0ef07f-2aec-46b0-b996-1db9913efa6d" />
 
-### v0.1 安装包
+### v0.1.1 安装包
 
-想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1)。
+想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.1)。
 安装包自带运行时，不需要另外安装 Node.js 或 npm；使用前请先安装 Codex Desktop。
 
 
@@ -163,7 +163,7 @@ Ctrl + Shift + Space
 运行：
 
 ```text
-beautiCode-Setup-0.1.0-win-x64.exe
+beautiCode-Setup-0.1.1-win-x64.exe
 ```
 
 安装包自带 Node.js 运行时。使用者不需要安装 Node.js、npm，也不需要保留

--- a/apps/tray/session-host.mjs
+++ b/apps/tray/session-host.mjs
@@ -336,6 +336,16 @@ const server = http.createServer(
       send(res, result.ok ? 200 : 422, result);
       return;
     }
+    if (req.method === "POST" && url === "/mode/tone") {
+      const body = await readBody(req);
+      if (!["dark", "light", "auto"].includes(body.tone)) {
+        send(res, 400, { ok: false, error: "tone must be dark, light, or auto" });
+        return;
+      }
+      const result = await session.setBackgroundTone(body.tone);
+      send(res, result.ok ? 200 : 422, result);
+      return;
+    }
     if (req.method === "POST" && url === "/shutdown") {
       send(res, 200, { ok: true });
       setImmediate(() => void shutdown(0));

--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -8,6 +8,40 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$script:TrayLogRoot = if ($env:LOCALAPPDATA) {
+  Join-Path $env:LOCALAPPDATA "beautiCode\logs"
+} else {
+  Join-Path ([System.IO.Path]::GetTempPath()) "beautiCode\logs"
+}
+$script:TrayLogPath = Join-Path $script:TrayLogRoot "tray.log"
+
+function Write-BcTrayLog([string]$Message) {
+  try {
+    if (-not (Test-Path -LiteralPath $script:TrayLogRoot)) {
+      New-Item -ItemType Directory -Path $script:TrayLogRoot -Force | Out-Null
+    }
+    Add-Content -LiteralPath $script:TrayLogPath `
+      -Value (("[{0:u}] {1}" -f (Get-Date).ToUniversalTime(), $Message)) `
+      -Encoding UTF8
+  } catch { }
+}
+
+trap {
+  $message = if ($_.Exception) { $_.Exception.Message } else { [string]$_ }
+  Write-BcTrayLog ("tray failed: {0}" -f $message)
+  try {
+    Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+    [System.Windows.Forms.MessageBox]::Show(
+      ("beautiCode 托盘启动失败：`n{0}`n`n日志：{1}" -f $message, $script:TrayLogPath),
+      "beautiCode",
+      [System.Windows.Forms.MessageBoxButtons]::OK,
+      [System.Windows.Forms.MessageBoxIcon]::Error
+    ) | Out-Null
+  } catch { }
+  exit 1
+}
+Write-BcTrayLog "tray starting"
+
 $script:trayInstanceMutex = $null
 $script:trayInstanceMutexOwned = $false
 $createdNew = $false
@@ -181,10 +215,16 @@ public sealed class BeautiCodeToggle : Control {
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
 $HostScript = Join-Path $PSScriptRoot "session-host.mjs"
+$CodexLaunchScript = Join-Path $RepoRoot "scripts\codex-launch.ps1"
 $ReleaseManifest = Join-Path $RepoRoot "release-manifest.json"
 $BundledNode = Join-Path $RepoRoot "runtime\node.exe"
 $coreDist = Join-Path $RepoRoot "packages\core\dist\index.js"
 $adapterDist = Join-Path $RepoRoot "packages\adapter-codex\dist\index.js"
+
+if (-not (Test-Path -LiteralPath $CodexLaunchScript -PathType Leaf)) {
+  throw "Missing Codex launch helper: $CodexLaunchScript"
+}
+. $CodexLaunchScript
 
 if ($NodePath) {
   if (-not (Test-Path -LiteralPath $NodePath -PathType Leaf)) {
@@ -200,9 +240,6 @@ if ($NodePath) {
 if (Test-Path -LiteralPath $ReleaseManifest -PathType Leaf) {
   $SkipBuild = $true
 }
-
-# Known ChatGPT / Codex Desktop AppX application user model id (Windows).
-$script:CodexAppUserModelId = "OpenAI.Codex_2p2nqsd0c76g0!App"
 
 if (-not (Test-Path -LiteralPath $HostScript)) {
   throw ("Missing session-host.mjs at {0}" -f $HostScript)
@@ -270,32 +307,45 @@ try {
 }
 $Token = -join ($TokenBytes | ForEach-Object { $_.ToString("x2") })
 
-function Escape-Arg([string]$Value) {
-  if ($Value -match '[\s"]') {
-    return '"' + ($Value -replace '"', '\"') + '"'
-  }
-  return $Value
+function ConvertTo-PsLiteral([string]$Value) {
+  return "'" + ($Value -replace "'", "''") + "'"
 }
 
-$argParts = @(
-  (Escape-Arg $HostScript)
+$nodeInvocationParts = @(
+  (ConvertTo-PsLiteral $Node),
+  (ConvertTo-PsLiteral $HostScript)
 )
 if ($Port -gt 0) {
-  $argParts += @("--port", "$Port")
+  $nodeInvocationParts += @("--port", "$Port")
 }
 if ($DataRoot) {
-  $argParts += @("--data-root", (Escape-Arg $DataRoot))
+  $nodeInvocationParts += @("--data-root", (ConvertTo-PsLiteral $DataRoot))
 }
 
+# Windows PowerShell 5.1 can throw while reading ProcessStartInfo.EnvironmentVariables
+# when the inherited process has both Path and PATH. Start a tiny PowerShell bridge,
+# pass the token through stdin, and let that bridge set the child-only environment.
+$nodeInvocation = [string]::Join(" ", $nodeInvocationParts)
+$bridgeScript = @"
+`$token = [Console]::In.ReadToEnd()
+if ([string]::IsNullOrWhiteSpace(`$token)) { throw "Missing beautiCode control token" }
+`$env:BEAUTICODE_CONTROL_TOKEN = `$token.Trim()
+& $nodeInvocation
+exit `$LASTEXITCODE
+"@
+$bridgeBytes = [System.Text.Encoding]::Unicode.GetBytes($bridgeScript)
+$bridgeCommand = [Convert]::ToBase64String($bridgeBytes)
+$powershell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+
 $psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName = $Node
-$psi.Arguments = [string]::Join(" ", $argParts)
+$psi.FileName = $powershell
+$psi.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $bridgeCommand"
 $psi.WorkingDirectory = $RepoRoot
 $psi.UseShellExecute = $false
+$psi.RedirectStandardInput = $true
 $psi.RedirectStandardOutput = $true
 $psi.RedirectStandardError = $true
 $psi.CreateNoWindow = $true
-$psi.EnvironmentVariables["BEAUTICODE_CONTROL_TOKEN"] = $Token
 
 $proc = New-Object System.Diagnostics.Process
 $proc.StartInfo = $psi
@@ -319,6 +369,8 @@ $errEvent = Register-ObjectEvent -InputObject $proc -EventName ErrorDataReceived
 [void]$proc.Start()
 $proc.BeginOutputReadLine()
 $proc.BeginErrorReadLine()
+$proc.StandardInput.WriteLine($Token)
+$proc.StandardInput.Close()
 
 $ready = $null
 $deadline = [datetime]::UtcNow.AddSeconds(20)
@@ -352,6 +404,7 @@ $cdpPort = [int]$ready.cdpPort
 $script:cdpPort = $cdpPort
 $BaseUrl = "http://127.0.0.1:$controlPort"
 Write-Host ("Tray control plane {0} (CDP :{1})" -f $BaseUrl, $cdpPort)
+Write-BcTrayLog ("session-host ready controlPort={0} cdpPort={1}" -f $controlPort, $cdpPort)
 
 function Invoke-BcApi {
   param(
@@ -444,6 +497,7 @@ function Test-BcImageExt([string]$Path) {
     ".jpg" { return $true }
     ".jpeg" { return $true }
     ".webp" { return $true }
+    ".avif" { return $true }
     default { return $false }
   }
 }
@@ -512,67 +566,21 @@ function Find-ChatGptExe {
   if ($script:cachedChatGptExe -and (Test-Path -LiteralPath $script:cachedChatGptExe)) {
     return $script:cachedChatGptExe
   }
-  # AppX InstallLocation is readable; avoid recursive WindowsApps walks (slow + ACL).
-  try {
-    $pkg = Get-AppxPackage -Name "OpenAI.Codex" -ErrorAction SilentlyContinue |
-      Sort-Object Version -Descending |
-      Select-Object -First 1
-    if ($pkg -and $pkg.InstallLocation) {
-      $candidate = Join-Path $pkg.InstallLocation "app\ChatGPT.exe"
-      if (Test-Path -LiteralPath $candidate) {
-        $script:cachedChatGptExe = $candidate
-        return $candidate
-      }
-    }
-  } catch { }
-  foreach ($p in @(
-      (Join-Path $env:LOCALAPPDATA "Programs\chatgpt\ChatGPT.exe"),
-      (Join-Path $env:LOCALAPPDATA "Programs\Codex\Codex.exe")
-    )) {
-    if ($p -and (Test-Path -LiteralPath $p)) {
-      $script:cachedChatGptExe = $p
-      return $p
-    }
-  }
-  return $null
+  $script:cachedChatGptExe = Find-BcCodexExecutable
+  return $script:cachedChatGptExe
 }
 
 function Start-ChatGptDesktop {
   param([int]$CdpPort = 9335)
-  if ($CdpPort -le 0 -or $CdpPort -gt 65535) { $CdpPort = 9335 }
   $errors = New-Object System.Collections.ArrayList
-  # Always prefer loopback CDP flags. AppX shell:AppsFolder launch ignores args.
-  $cdpArgs = @(
-    "--remote-debugging-address=127.0.0.1",
-    ("--remote-debugging-port={0}" -f $CdpPort)
-  )
-  $exe = Find-ChatGptExe
-  if ($exe) {
-    try {
-      $psi = New-Object System.Diagnostics.ProcessStartInfo
-      $psi.FileName = $exe
-      $psi.Arguments = ($cdpArgs -join " ")
-      $psi.UseShellExecute = $true
-      [void][System.Diagnostics.Process]::Start($psi)
-      return $true
-    } catch {
-      [void]$errors.Add(("exe: {0}" -f $_.Exception.Message))
-    }
-  }
   try {
-    Start-Process -FilePath "explorer.exe" -ArgumentList ("shell:AppsFolder\{0}" -f $script:CodexAppUserModelId) -ErrorAction Stop | Out-Null
-    [void]$errors.Add("AUMID launch has no CDP flags; use tray Restart after enabling debug build, or open with flags manually.")
+    $result = Start-BcCodexWithCdp -CdpPort $CdpPort
+    if ($result.Method -eq "appx") {
+      [void]$errors.Add("Store launch may ignore custom CDP arguments; beautiCode will keep discovering the host.")
+    }
     return $true
   } catch {
-    [void]$errors.Add(("AUMID: {0}" -f $_.Exception.Message))
-  }
-  foreach ($name in @("ChatGPT", "Codex")) {
-    try {
-      Start-Process $name -ErrorAction Stop
-      return $true
-    } catch {
-      [void]$errors.Add(("{0}: {1}" -f $name, $_.Exception.Message))
-    }
+    [void]$errors.Add(("Codex launch: {0}" -f $_.Exception.Message))
   }
   throw ("Cannot start ChatGPT/Codex. {0}" -f ([string]::Join(" | ", @($errors))))
 }
@@ -730,7 +738,7 @@ function Invoke-BcEnsureHostAndReapply {
     } else {
       Show-Tip -Title $L.AppName -Text $L.StartingChat -Icon Info
     }
-    $launchPort = if ($preferred -gt 0) { $preferred } else { 9335 }
+    $launchPort = Get-BcLoopbackCdpPort -Preferred $preferred
     [void](Start-ChatGptDesktop -CdpPort $launchPort)
     # Codex cold start is the real wall clock; poll aggressively so we attach
     # as soon as :9335 answers instead of sleeping 700ms between probes.
@@ -766,6 +774,8 @@ $script:notify = $null
 $script:fishMode = $false
 # Video mute preference (default muted). Process-local; independent of fish.
 $script:videoMuted = $true
+# CSS overlay tone. Process-local; dark preserves the previous appearance.
+$script:backgroundTone = "dark"
 $script:fishHotkeyRegistered = $false
 $script:fishNativeWindow = $null
 # WM_HOTKEY id — arbitrary non-zero; unique per this process.
@@ -796,6 +806,10 @@ $L = @{
   FishLabel      = (U "6478 9C7C")                                         # 摸鱼
   VideoSound     = (U "89C6 9891 58F0 97F3")                               # 视频声音
   VideoSoundOn   = (U "89C6 9891 58F0 97F3 0020 2713")                     # 视频声音 ✓
+  BackgroundTone = (U "80CC 666F 6837 5F0F")                               # 背景样式
+  ToneDark       = (U "6DF1 8272")                                         # 深色
+  ToneLight      = (U "6D45 8272")                                         # 浅色
+  ToneAuto       = (U "8DDF 968F 7CFB 7EDF")                               # 跟随系统
   SoundOnTip     = (U "5DF2 5F00 542F 89C6 9891 58F0 97F3 3002")           # 已开启视频声音。
   SoundOffTip    = (U "5DF2 9759 97F3 89C6 9891 3002")                     # 已静音视频。
   SoundBlocked   = (U "5DF2 5C1D 8BD5 5F00 58F0 FF0C 4F46 88AB 6D4F 89C8 5668 81EA 52A8 64AD 653E 7B56 7565 62E6 622A FF0C 4ECD 4FDD 6301 9759 97F3 64AD 653E 3002") # 已尝试开声，但被浏览器自动播放策略拦截，仍保持静音播放。
@@ -826,7 +840,7 @@ $L = @{
   PickMp4        = (U "9009 62E9 0020 0062 0065 0061 0075 0074 0069 0043 006F 0064 0065 0020 89C6 9891 80CC 666F") # 选择 beautiCode 视频背景
   ImagesLabel    = (U "56FE 7247 6587 4EF6")                               # 图片文件
   Mp4Label       = (U "004D 0050 0034 0020 89C6 9891")                     # MP4 视频
-  NeedImage      = (U "8BF7 9009 62E9 0020 002E 0070 006E 0067 002F 002E 006A 0070 0067 002F 002E 006A 0070 0065 0067 002F 002E 0077 0065 0062 0070 0020 56FE 7247 3002") # 请选择 .png/.jpg/.jpeg/.webp 图片。
+  NeedImage      = (U "8BF7 9009 62E9 0020 002E 0070 006E 0067 002F 002E 006A 0070 0067 002F 002E 006A 0070 0065 0067 002F 002E 0077 0065 0062 0070 002F 002E 0061 0076 0069 0066 0020 56FE 7247 3002") # 请选择 .png/.jpg/.jpeg/.webp/.avif 图片。
   NeedMp4        = (U "8BF7 9009 62E9 0020 002E 006D 0070 0034 0020 6587 4EF6 3002") # 请选择 .mp4 文件。
   ImgOk          = (U "80CC 666F 56FE 5DF2 66F4 65B0 3002")               # 背景图已更新。
   VidOk          = (U "89C6 9891 80CC 666F 5DF2 66F4 65B0 3002")         # 视频背景已更新。
@@ -933,6 +947,9 @@ function Get-BcStatusLine {
     if ($null -ne $st.muted) {
       $script:videoMuted = [bool]$st.muted
     }
+    if ($st.tone -in @("dark", "light", "auto")) {
+      $script:backgroundTone = [string]$st.tone
+    }
     $base = if ($script:busy) { $L.StatusBusy } else { $L.StatusRunning }
     # Deliberately omit CDP port and generation — keep tray UX simple.
     $parts = New-Object System.Collections.ArrayList
@@ -946,6 +963,54 @@ function Get-BcStatusLine {
   } catch {
     return $L.StatusOffline
   }
+}
+
+function Get-BcToneLabel([string]$Tone) {
+  switch ($Tone) {
+    "light" { return $L.ToneLight }
+    "auto" { return $L.ToneAuto }
+    default { return $L.ToneDark }
+  }
+}
+
+function Invoke-BcSetTone {
+  param([string]$Tone)
+  if ($Tone -notin @("dark", "light", "auto")) { return }
+  if ($script:busy) {
+    Show-Tip -Title $L.AppName -Text $L.BusyTip -Icon Warning
+    return
+  }
+  $script:busy = $true
+  try {
+    $res = Invoke-BcApi -Method Post -Path "/mode/tone" -Body @{ tone = $Tone }
+    if ($res.ok) {
+      $script:backgroundTone = if ($res.tone -in @("dark", "light", "auto")) {
+        [string]$res.tone
+      } else {
+        $Tone
+      }
+      if ($null -ne $script:bcToneButton) {
+        $script:bcToneButton.Text = "{0} · {1}" -f $L.BackgroundTone, (Get-BcToneLabel $script:backgroundTone)
+      }
+      Show-Tip -Title $L.AppName -Text ("{0} · {1}" -f $L.BackgroundTone, (Get-BcToneLabel $script:backgroundTone)) -Icon Info
+    } else {
+      $err = if ($res.error) { [string]$res.error } else { $L.ApplyFail }
+      Show-Tip -Title $L.AppName -Text $err -Icon Error
+    }
+  } catch {
+    Show-BcError -Message ("{0}" -f $_)
+  } finally {
+    $script:busy = $false
+  }
+}
+
+function Invoke-BcCycleTone {
+  $next = switch ($script:backgroundTone) {
+    "dark" { "light" }
+    "light" { "auto" }
+    default { "dark" }
+  }
+  Invoke-BcSetTone -Tone $next
 }
 
 # Toggle fish mode via control plane. Attribute-only on host — no media rebuild.
@@ -1151,7 +1216,7 @@ $menu = New-Object System.Windows.Forms.ContextMenuStrip
 $script:fallbackMenu = $menu
 
 # Image: common formats. Video: MP4 only (Dream Skin style — no "all files").
-$imgFilter = ("{0}|*.png;*.jpg;*.jpeg;*.webp" -f $L.ImagesLabel)
+$imgFilter = ("{0}|*.png;*.jpg;*.jpeg;*.webp;*.avif" -f $L.ImagesLabel)
 $vidFilter = ("{0}|*.mp4" -f $L.Mp4Label)
 
 function Rebuild-BcTrayMenu {
@@ -1233,6 +1298,22 @@ function Rebuild-BcTrayMenu {
   $null = Add-BcTrayItem -Items $menu.Items -Text $soundText -Enabled:(-not $opActive) -Name "sound" -Action {
     Invoke-BcToggleMuted
   }
+
+  $toneMenu = New-Object System.Windows.Forms.ToolStripMenuItem
+  $toneMenu.Text = ("{0} · {1}" -f $L.BackgroundTone, (Get-BcToneLabel $script:backgroundTone))
+  $toneMenu.Name = "tone"
+  $toneMenu.Enabled = -not $opActive
+  $null = Add-BcTrayItem -Items $toneMenu.DropDownItems -Text $L.ToneDark -Enabled:(-not $opActive) -Name "tone-dark" -Action {
+    Invoke-BcSetTone -Tone "dark"
+  }
+  $null = Add-BcTrayItem -Items $toneMenu.DropDownItems -Text $L.ToneLight -Enabled:(-not $opActive) -Name "tone-light" -Action {
+    Invoke-BcSetTone -Tone "light"
+  }
+  $null = Add-BcTrayItem -Items $toneMenu.DropDownItems -Text $L.ToneAuto -Enabled:(-not $opActive) -Name "tone-auto" -Action {
+    Invoke-BcSetTone -Tone "auto"
+  }
+  $null = $toneMenu.add_Click({ Invoke-BcCycleTone })
+  $null = $menu.Items.Add($toneMenu)
 
   [void]$menu.Items.Add((New-Object System.Windows.Forms.ToolStripSeparator))
 
@@ -1635,13 +1716,25 @@ function Set-BcFallbackMenuStyle {
   $menu.ShowImageMargin = $false
   $menu.Padding = New-Object System.Windows.Forms.Padding(5)
   foreach ($item in @($menu.Items)) {
-    $item.BackColor = $script:bcUiColors.Panel
-    $item.ForeColor = if ($item.Enabled) { $script:bcUiColors.Text } else { $script:bcUiColors.Muted }
+    $isClear = $item.Name -eq "clear"
+    $item.BackColor = if ($isClear -and $item.Enabled) { $script:bcUiColors.DangerSurface } else { $script:bcUiColors.Panel }
+    $item.ForeColor = if ($isClear -and $item.Enabled) {
+      $script:bcUiColors.Danger
+    } elseif ($item.Enabled) {
+      $script:bcUiColors.Text
+    } else {
+      $script:bcUiColors.Muted
+    }
     $item.Font = $script:bcBodyFont
     if ($item -is [System.Windows.Forms.ToolStripDropDownItem]) {
       $item.DropDown.BackColor = $script:bcUiColors.Panel
       $item.DropDown.ForeColor = $script:bcUiColors.Text
       $item.DropDown.Font = $script:bcBodyFont
+      foreach ($child in @($item.DropDownItems)) {
+        $child.BackColor = $script:bcUiColors.Panel
+        $child.ForeColor = if ($child.Enabled) { $script:bcUiColors.Text } else { $script:bcUiColors.Muted }
+        $child.Font = $script:bcBodyFont
+      }
     }
   }
 }
@@ -1761,9 +1854,9 @@ function Update-BcTrayPanel {
     $L.NoBackground
   }
   $script:bcImageCard.Meta.Text = if ($isImage) {
-    "PNG/JPG/WEBP · {0}" -f $L.CurrentMedia
+    "PNG/JPG/WEBP/AVIF · {0}" -f $L.CurrentMedia
   } else {
-    "PNG · JPG · WEBP"
+    "PNG · JPG · WEBP · AVIF"
   }
   $script:bcVideoCard.Meta.Text = if ($isVideo) {
     "MP4 · {0}" -f $L.CurrentMedia
@@ -1782,6 +1875,8 @@ function Update-BcTrayPanel {
   $script:bcSoundSwitch.State.Text = if ($soundOn) { $L.EnabledLabel } else { $L.DisabledLabel }
   $script:bcSoundSwitch.State.ForeColor = if ($soundOn) { $script:bcUiColors.Jade } else { $script:bcUiColors.Muted }
   $script:bcSoundSwitch.Toggle.Checked = $soundOn
+
+  $script:bcToneButton.Text = "{0} · {1}" -f $L.BackgroundTone, (Get-BcToneLabel $script:backgroundTone)
 
   $savedItem = Get-BcMenuItem -Name "themes"
   $themeText = $L.NoSavedThemes
@@ -1815,6 +1910,10 @@ function Invoke-BcPanelAction {
   if (-not $ActionName) { return }
   if ($ActionName -eq "themes") {
     Show-BcThemeOverlay
+    return
+  }
+  if ($ActionName -eq "tone") {
+    Invoke-BcCycleTone
     return
   }
   if ($null -ne $script:trayPanel) { $script:trayPanel.Hide() }
@@ -1985,6 +2084,10 @@ function Initialize-BcTrayPanel {
     Jade = Get-BcUiColor "#86AA91"
     JadeDeep = Get-BcUiColor "#496854"
     Copper = Get-BcUiColor "#B98265"
+    Danger = Get-BcUiColor "#FF6B6B"
+    DangerSurface = Get-BcUiColor "#542B2B"
+    DangerHover = Get-BcUiColor "#713333"
+    DangerDeep = Get-BcUiColor "#8F3E3E"
     ToggleOff = Get-BcUiColor "#4F554E"
     ToggleOffBorder = Get-BcUiColor "#737A71"
     ToggleKnob = Get-BcUiColor "#F1F3EE"
@@ -2059,10 +2162,12 @@ function Initialize-BcTrayPanel {
     -Meta "MP4" -ActionName "video" -X 212 -Y 29 -Width 190
 
   $clear = New-BcUiButton -Text $L.ClearCurrentBg -X 14 -Y 113 -Width 388 -Height 32 `
-    -Font $script:bcMetaFont -BackColor $script:bcUiColors.Window `
-    -ForeColor $script:bcUiColors.Muted -BorderColor $script:bcUiColors.Window `
+    -Font $script:bcMetaFont -BackColor $script:bcUiColors.DangerSurface `
+    -ForeColor $script:bcUiColors.Danger -BorderColor $script:bcUiColors.Danger `
     -Align ([System.Drawing.ContentAlignment]::MiddleLeft)
   $clear.Padding = New-Object System.Windows.Forms.Padding(8, 0, 0, 0)
+  $clear.FlatAppearance.MouseOverBackColor = $script:bcUiColors.DangerHover
+  $clear.FlatAppearance.MouseDownBackColor = $script:bcUiColors.DangerDeep
   Register-BcPanelAction -Control $clear -ActionName "clear"
   [void]$body.Controls.Add($clear)
 
@@ -2105,6 +2210,14 @@ function Initialize-BcTrayPanel {
   $saveTheme.Padding = New-Object System.Windows.Forms.Padding(8, 0, 0, 0)
   Register-BcPanelAction -Control $saveTheme -ActionName "save-theme"
   [void]$body.Controls.Add($saveTheme)
+
+  $script:bcToneButton = New-BcUiButton -Text ("{0} · {1}" -f $L.BackgroundTone, (Get-BcToneLabel $script:backgroundTone)) -X 14 -Y 405 -Width 388 -Height 38 `
+    -Font $script:bcBodyFont -BackColor $script:bcUiColors.Panel `
+    -ForeColor $script:bcUiColors.Jade -BorderColor $script:bcUiColors.Line `
+    -Align ([System.Drawing.ContentAlignment]::MiddleLeft)
+  $script:bcToneButton.Padding = New-Object System.Windows.Forms.Padding(8, 0, 0, 0)
+  Register-BcPanelAction -Control $script:bcToneButton -ActionName "tone"
+  [void]$body.Controls.Add($script:bcToneButton)
 
   $footer = New-Object System.Windows.Forms.Panel
   $footer.Location = New-Object System.Drawing.Point(0, 593)
@@ -2151,7 +2264,9 @@ function Initialize-BcTrayPanel {
     @{ Control = $reapply; Radius = 9 },
     @{ Control = $script:bcImageCard.Panel; Radius = 10 },
     @{ Control = $script:bcVideoCard.Panel; Radius = 10 },
-    @{ Control = $themeCard; Radius = 10 }
+    @{ Control = $themeCard; Radius = 10 },
+    @{ Control = $clear; Radius = 8 },
+    @{ Control = $script:bcToneButton; Radius = 8 }
   )
   Set-BcIntegerLayoutTree -Control $form
   Enable-BcDoubleBufferTree -Control $form

--- a/docs/windows-installer.md
+++ b/docs/windows-installer.md
@@ -58,3 +58,15 @@ this pipeline for a commercial distribution.
 The installer targets x64-compatible Windows. It does not bundle, patch, or
 modify Codex Desktop. Runtime integration still depends on Codex exposing a
 healthy loopback CDP endpoint.
+
+The current bundled Node.js runtime requires 64-bit Windows 10 version 1809
+(build 17763) or newer. Codex Desktop must be installed separately. If Codex
+was already running without loopback CDP, use the tray's “Apply or re-apply”
+action; it will restart Codex only after the normal confirmation prompt.
+
+Startup diagnostics are written to:
+
+```text
+%LOCALAPPDATA%\beautiCode\logs\engine-launcher.log
+%LOCALAPPDATA%\beautiCode\logs\tray.log
+```

--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -4,7 +4,7 @@
 #define MyAppPublisher "beautiCode"
 
 #ifndef MyAppVersion
-  #define MyAppVersion "0.1.1"
+  #define MyAppVersion "0.1.2"
 #endif
 
 #ifndef StageDir

--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -1,3 +1,5 @@
+#pragma codepage "utf-8"
+
 #define MyAppName "beautiCode"
 #define MyAppPublisher "beautiCode"
 
@@ -22,6 +24,7 @@ DefaultDirName={localappdata}\Programs\beautiCode
 DefaultGroupName=beautiCode
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
+MinVersion=10.0.17763
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 OutputDir={#OutputDir}

--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -4,7 +4,7 @@
 #define MyAppPublisher "beautiCode"
 
 #ifndef MyAppVersion
-  #define MyAppVersion "0.1.0"
+  #define MyAppVersion "0.1.1"
 #endif
 
 #ifndef StageDir

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beauticode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beauticode",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beauticode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beauticode",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beauticode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Local image/video backgrounds for supported coding hosts. Unofficial.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beauticode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Local image/video backgrounds for supported coding hosts. Unofficial.",

--- a/packages/adapter-codex/src/host-applier.ts
+++ b/packages/adapter-codex/src/host-applier.ts
@@ -1,6 +1,7 @@
 import type {
   HostApplyPayload,
   HostApplier,
+  BackgroundTone,
   VerifyExpectation,
   VerifyResult,
 } from "@beauticode/core";
@@ -70,6 +71,8 @@ export class CodexHostApplier implements HostApplier {
    * Process-local; re-asserted after inject / blob attach so watch cannot drop it.
    */
   private videoMuted = true;
+  /** CSS overlay preference; dark preserves the pre-tone behavior. */
+  private backgroundTone: BackgroundTone = "dark";
 
   constructor(opts: CodexHostApplierOptions) {
     if (!Number.isInteger(opts.port) || opts.port < 1 || opts.port > 65535) {
@@ -300,6 +303,9 @@ export class CodexHostApplier implements HostApplier {
               await setSessionFishMode(session, true).catch(() => false);
             }
             await setSessionMuted(session, this.videoMuted).catch(() => null);
+            await setSessionBackgroundTone(session, this.backgroundTone).catch(
+              () => false,
+            );
             ok += 1;
             continue;
           }
@@ -314,6 +320,9 @@ export class CodexHostApplier implements HostApplier {
               await setSessionFishMode(session, true).catch(() => false);
             }
             await setSessionMuted(session, this.videoMuted).catch(() => null);
+            await setSessionBackgroundTone(session, this.backgroundTone).catch(
+              () => false,
+            );
             ok += 1;
             continue;
           }
@@ -329,6 +338,9 @@ export class CodexHostApplier implements HostApplier {
             await setSessionFishMode(session, true).catch(() => false);
           }
           await setSessionMuted(session, this.videoMuted).catch(() => null);
+          await setSessionBackgroundTone(session, this.backgroundTone).catch(
+            () => false,
+          );
           ok += 1;
         } catch (err) {
           errors.push(
@@ -425,6 +437,63 @@ export class CodexHostApplier implements HostApplier {
       };
     }
     return { ok: true, fish: this.fishMode, sessions: okCount };
+  }
+
+  /** Change only the CSS overlay tone; media and generation stay untouched. */
+  async setBackgroundTone(tone: BackgroundTone): Promise<{
+    ok: boolean;
+    tone: BackgroundTone;
+    sessions: number;
+    error?: string;
+  }> {
+    this.assertOpen();
+    const want: BackgroundTone =
+      tone === "light" || tone === "auto" ? tone : "dark";
+    this.backgroundTone = want;
+    // There may be no injected runtime yet (fresh tray / cleared background).
+    // Remember the preference and apply it on the next background publish.
+    if (!this.lastPayload || this.lastPayload.media === "clear") {
+      return { ok: true, tone: this.backgroundTone, sessions: 0 };
+    }
+    try {
+      if (this.sessions.size === 0) {
+        await this.connect();
+      } else {
+        await this.reconcileSessions();
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        tone: this.backgroundTone,
+        sessions: 0,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    let okCount = 0;
+    const errors: string[] = [];
+    for (const [id, session] of this.sessions) {
+      if (session.closed) {
+        this.sessions.delete(id);
+        continue;
+      }
+      try {
+        if (await setSessionBackgroundTone(session, want)) okCount += 1;
+        else errors.push(`${id}: renderer does not support background tone`);
+      } catch (err) {
+        errors.push(
+          `${id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    if (okCount === 0) {
+      return {
+        ok: false,
+        tone: this.backgroundTone,
+        sessions: 0,
+        error: errors[0] ?? "Could not set background tone on any session",
+      };
+    }
+    return { ok: true, tone: this.backgroundTone, sessions: okCount };
   }
 
   /**
@@ -807,6 +876,23 @@ async function setSessionMuted(
     hasVideo: boolean;
   } | null>(expr, { userGesture: true });
   return result ?? null;
+}
+
+async function setSessionBackgroundTone(
+  session: CdpSession,
+  tone: BackgroundTone,
+): Promise<boolean> {
+  const toneLiteral = JSON.stringify(tone);
+  const expr = `(() => {
+    const api = window.__BEAUTICODE_BG__;
+    if (!api || typeof api.setBackgroundTone !== "function") return false;
+    try {
+      return Boolean(api.setBackgroundTone(${toneLiteral}));
+    } catch (_) {
+      return false;
+    }
+  })()`;
+  return Boolean(await session.evaluate<boolean>(expr));
 }
 
 async function readSessionPlaybackPosition(

--- a/packages/adapter-codex/src/renderer/background-runtime.js
+++ b/packages/adapter-codex/src/renderer/background-runtime.js
@@ -372,7 +372,7 @@
           '[data-testid*="conversation"]',
           '[data-testid*="thread"]',
           '[data-testid*="turn"]',
-          'main.main-surface [data-message-id]',
+          'body > #root main [data-message-id]',
         ].join(", "),
       );
       if (thread && isVisibleEl(thread)) return true;
@@ -380,7 +380,7 @@
       // Open task header: folder glyph + title in the main app header
       // (matches the project task chrome in Codex Desktop).
       const header = document.querySelector(
-        "main.main-surface header.app-header-tint, main.main-surface header",
+        "body > #root main header.app-header-tint, body > #root main header",
       );
       if (header && isVisibleEl(header)) {
         const headerText = (header.textContent || "").replace(/\s+/g, " ").trim();
@@ -388,7 +388,7 @@
         if (headerText.length >= 2 && !/^(codex|chatgpt|home|首页)?$/i.test(headerText)) {
           // Require composer or main role so empty shells do not false-dim.
           const workSurface = document.querySelector(
-            "main.main-surface .composer-surface-chrome, main.main-surface [role='main'], main.main-surface .thread-scroll-container",
+            "body > #root main .composer-surface-chrome, body > #root main [role='main'], body > #root main .thread-scroll-container",
           );
           if (workSurface && isVisibleEl(workSurface)) return true;
         }

--- a/packages/adapter-codex/src/renderer/background-runtime.js
+++ b/packages/adapter-codex/src/renderer/background-runtime.js
@@ -208,6 +208,21 @@
     videoMuted = true;
   }
 
+  // Background tone is a CSS-only preference. Keep dark as the legacy
+  // default, and carry the preference across same-generation/rebuild paths.
+  const normalizeTone = (value) =>
+    value === "light" || value === "auto" ? value : "dark";
+  let backgroundTone = "dark";
+  try {
+    if (previous && typeof previous.getBackgroundTone === "function") {
+      backgroundTone = normalizeTone(previous.getBackgroundTone());
+    } else {
+      backgroundTone = normalizeTone(root.getAttribute("data-bc-tone"));
+    }
+  } catch (_) {
+    backgroundTone = "dark";
+  }
+
   // Optional initial seek for saved-theme restore (seconds). Applied once when
   // the live <video> has metadata. Invalid / past end → 0 (start over).
   let pendingStartAt = null;
@@ -712,6 +727,13 @@
     };
   };
 
+  const setBackgroundTone = (tone) => {
+    if (!isCurrent()) return false;
+    backgroundTone = normalizeTone(tone);
+    setAttrs();
+    return true;
+  };
+
   /**
    * Clamp a desired seek time against live duration.
    * Invalid / NaN / negative / past end → 0 (start over, per product rule).
@@ -842,6 +864,7 @@
       root.removeAttribute("data-bc-generation");
       root.removeAttribute("data-bc-working");
       root.removeAttribute("data-bc-fish");
+      root.removeAttribute("data-bc-tone");
       fishMode = false;
       stopWorkingWatch();
       return;
@@ -866,6 +889,7 @@
       videoReady || handoffReady ? "true" : "false",
     );
     root.setAttribute("data-bc-generation", String(gen));
+    root.setAttribute("data-bc-tone", backgroundTone);
     if (working) root.setAttribute("data-bc-working", "true");
     else root.removeAttribute("data-bc-working");
     applyFishAttr();
@@ -1756,6 +1780,7 @@
         root.removeAttribute("data-bc-generation");
         root.removeAttribute("data-bc-working");
         root.removeAttribute("data-bc-fish");
+        root.removeAttribute("data-bc-tone");
         fishMode = false;
       }
       // handoff: leave data-bc-fish for the next generation to inherit.
@@ -1771,6 +1796,12 @@
     },
     setMuted(muted) {
       return setMuted(muted);
+    },
+    isBackgroundTone() {
+      return backgroundTone;
+    },
+    setBackgroundTone(tone) {
+      return setBackgroundTone(tone);
     },
     /** Re-apply stored mute preference (used after CDP attach / heal). */
     applyMutePreference() {

--- a/packages/adapter-codex/src/renderer/background.css
+++ b/packages/adapter-codex/src/renderer/background.css
@@ -260,7 +260,9 @@ html[data-bc-active="true"] body > #root main > header.app-header-tint {
 
 /* Main content frame / scroll fades that paint opaque tokens. */
 html[data-bc-active="true"] body > #root main .app-shell-main-content-frame,
-html[data-bc-active="true"] body > #root main .app-shell-main-content-top-fade {
+html[data-bc-active="true"] body > #root main .app-shell-main-content-top-fade,
+html[data-bc-active="true"] body > #root main
+  [class*="_MainContentTopFade_"] {
   background: transparent !important;
   background-image: none !important;
 }

--- a/packages/adapter-codex/src/renderer/background.css
+++ b/packages/adapter-codex/src/renderer/background.css
@@ -7,6 +7,89 @@
   --bc-main-edge: rgba(17, 19, 24, 0.40);
   --bc-main-mid: rgba(17, 19, 24, 0.26);
   --bc-main-far: rgba(17, 19, 24, 0.12);
+  /* Keep the original dark treatment as the compatibility default. */
+  --bc-stage-veil:
+    linear-gradient(
+      180deg,
+      rgba(17, 19, 24, 0.10) 0%,
+      rgba(17, 19, 24, 0.18) 36%,
+      rgba(17, 19, 24, 0.42) 100%
+    ),
+    linear-gradient(
+      90deg,
+      rgba(17, 19, 24, 0.34) 0%,
+      rgba(17, 19, 24, 0.14) 52%,
+      rgba(17, 19, 24, 0.06) 100%
+    );
+  --bc-video-filter: brightness(1.08) saturate(1.03);
+  --bc-working-main:
+    linear-gradient(
+      90deg,
+      rgba(17, 19, 24, 0.90) 0%,
+      rgba(17, 19, 24, 0.80) 64%,
+      rgba(17, 19, 24, 0.70) 100%
+    );
+}
+
+/* Light background mode: use bright translucent glass layers so the image
+   remains visible. It only changes beautiCode's overlay, not Codex's native
+   application theme or text colors. */
+html[data-bc-tone="light"] {
+  --bc-sidebar: rgba(255, 255, 255, 0.56);
+  --bc-main-edge: rgba(255, 255, 255, 0.44);
+  --bc-main-mid: rgba(255, 255, 255, 0.30);
+  --bc-main-far: rgba(255, 255, 255, 0.16);
+  --bc-stage-veil:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.06) 0%,
+      rgba(255, 255, 255, 0.12) 36%,
+      rgba(255, 255, 255, 0.24) 100%
+    ),
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.18) 0%,
+      rgba(255, 255, 255, 0.10) 52%,
+      rgba(255, 255, 255, 0.04) 100%
+    );
+  --bc-video-filter: brightness(0.98) saturate(0.96);
+  --bc-working-main:
+    linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.68) 0%,
+      rgba(255, 255, 255, 0.54) 64%,
+      rgba(255, 255, 255, 0.40) 100%
+    );
+}
+
+@media (prefers-color-scheme: light) {
+  html[data-bc-tone="auto"] {
+    --bc-sidebar: rgba(255, 255, 255, 0.56);
+    --bc-main-edge: rgba(255, 255, 255, 0.44);
+    --bc-main-mid: rgba(255, 255, 255, 0.30);
+    --bc-main-far: rgba(255, 255, 255, 0.16);
+    --bc-stage-veil:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.06) 0%,
+        rgba(255, 255, 255, 0.12) 36%,
+        rgba(255, 255, 255, 0.24) 100%
+      ),
+      linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.18) 0%,
+        rgba(255, 255, 255, 0.10) 52%,
+        rgba(255, 255, 255, 0.04) 100%
+      );
+    --bc-video-filter: brightness(0.98) saturate(0.96);
+    --bc-working-main:
+      linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.68) 0%,
+        rgba(255, 255, 255, 0.54) 64%,
+        rgba(255, 255, 255, 0.40) 100%
+      );
+  }
 }
 
 /* Clear opaque page backdrops so the fixed stage can show through. */
@@ -48,19 +131,7 @@ html[data-bc-active="true"] body >
   z-index: 3;
   pointer-events: none;
   /* Soft readability veil over art (Dream-Skin task shade/fade simplified). */
-  background:
-    linear-gradient(
-      180deg,
-      rgba(17, 19, 24, 0.10) 0%,
-      rgba(17, 19, 24, 0.18) 36%,
-      rgba(17, 19, 24, 0.42) 100%
-    ),
-    linear-gradient(
-      90deg,
-      rgba(17, 19, 24, 0.34) 0%,
-      rgba(17, 19, 24, 0.14) 52%,
-      rgba(17, 19, 24, 0.06) 100%
-    );
+  background: var(--bc-stage-veil);
 }
 
 #beauticode-bg-stage img,
@@ -86,7 +157,7 @@ html[data-bc-active="true"] body >
      Pending replacements stay opacity:0 via inline style so a handed-off
      previous video (no inline opacity) can remain visible underneath. */
   opacity: 0;
-  filter: brightness(1.08) saturate(1.03);
+  filter: var(--bc-video-filter);
 }
 
 /* Ready video: CSS reveals elements that cleared their inline opacity:0. */
@@ -167,12 +238,7 @@ html[data-bc-active="true"] main.main-surface {
    so home ↔ project transition is seamless on the sidebar. */
 html[data-bc-active="true"][data-bc-working="true"] main.main-surface {
   /* Tiny step darker — keep translucent so thread text stays readable. */
-  background: linear-gradient(
-    90deg,
-    rgba(17, 19, 24, 0.90) 0%,
-    rgba(17, 19, 24, 0.80) 64%,
-    rgba(17, 19, 24, 0.70) 100%
-  ) !important;
+  background: var(--bc-working-main) !important;
   transition: background 240ms ease;
 }
 

--- a/packages/adapter-codex/src/renderer/background.css
+++ b/packages/adapter-codex/src/renderer/background.css
@@ -197,7 +197,7 @@ html[data-bc-active="true"][data-bc-media="video-pending"]
    - Video keeps playing under both columns.
    Implementation: do NOT retouch #beauticode-bg-stage::before or media
    filters on working — those are full-window and would shift the left.
-   Dim only via main.main-surface wash. */
+   Dim only via the primary main surface wash. */
 
 /* ---- Left sidebar: translucent so art shows ---- */
 html[data-bc-active="true"] aside.app-shell-left-panel {
@@ -221,8 +221,9 @@ html[data-bc-active="true"] aside.app-shell-left-panel nav {
 }
 
 /* ---- Main surface ---- */
-html[data-bc-active="true"] main.main-surface {
+html[data-bc-active="true"] body > #root main {
   position: relative !important;
+  background-color: transparent !important;
   background: linear-gradient(
     90deg,
     var(--bc-main-edge),
@@ -236,21 +237,21 @@ html[data-bc-active="true"] main.main-surface {
 
 /* Task page: ONLY the right column. Stage veil + left aside stay as home
    so home ↔ project transition is seamless on the sidebar. */
-html[data-bc-active="true"][data-bc-working="true"] main.main-surface {
+html[data-bc-active="true"][data-bc-working="true"] body > #root main {
   /* Tiny step darker — keep translucent so thread text stays readable. */
   background: var(--bc-working-main) !important;
   transition: background 240ms ease;
 }
 
 /* No secondary art painted on main — stage owns the picture. */
-html[data-bc-active="true"] main.main-surface::before,
-html[data-bc-active="true"] main.main-surface::after {
+html[data-bc-active="true"] body > #root main::before,
+html[data-bc-active="true"] body > #root main::after {
   content: none !important;
   background-image: none !important;
   background: transparent !important;
 }
 
-html[data-bc-active="true"] main.main-surface > header.app-header-tint {
+html[data-bc-active="true"] body > #root main > header.app-header-tint {
   background: transparent !important;
   border-bottom: 0 !important;
   box-shadow: none !important;
@@ -258,13 +259,13 @@ html[data-bc-active="true"] main.main-surface > header.app-header-tint {
 }
 
 /* Main content frame / scroll fades that paint opaque tokens. */
-html[data-bc-active="true"] main.main-surface .app-shell-main-content-frame,
-html[data-bc-active="true"] main.main-surface .app-shell-main-content-top-fade {
+html[data-bc-active="true"] body > #root main .app-shell-main-content-frame,
+html[data-bc-active="true"] body > #root main .app-shell-main-content-top-fade {
   background: transparent !important;
   background-image: none !important;
 }
 
-html[data-bc-active="true"] main.main-surface
+html[data-bc-active="true"] body > #root main
   .thread-scroll-container
   .bg-gradient-to-t.from-token-main-surface-primary {
   background-image: none !important;
@@ -272,7 +273,7 @@ html[data-bc-active="true"] main.main-surface
 }
 
 /* Home hero card chrome — keep interactive, drop solid fill. */
-html[data-bc-active="true"] main.main-surface
+html[data-bc-active="true"] body > #root main
   [role="main"]:has([data-testid="home-icon"])
   > div:first-child
   > div:first-child
@@ -284,7 +285,7 @@ html[data-bc-active="true"] main.main-surface
   box-shadow: none !important;
 }
 
-html[data-bc-active="true"] main.main-surface
+html[data-bc-active="true"] body > #root main
   [role="main"]:has([data-testid="home-icon"])
   > div:first-child
   > div:first-child
@@ -293,7 +294,7 @@ html[data-bc-active="true"] main.main-surface
 }
 
 /* role=main region itself */
-html[data-bc-active="true"] main.main-surface [role="main"] {
+html[data-bc-active="true"] body > #root main [role="main"] {
   background: transparent !important;
 }
 

--- a/packages/adapter-codex/src/session.ts
+++ b/packages/adapter-codex/src/session.ts
@@ -8,6 +8,7 @@ import {
   type ApplyInput,
   type ApplyResult,
   type BackgroundManifest,
+  type BackgroundTone,
   type SavedThemeInfo,
 } from "@beauticode/core";
 import { CodexHostApplier } from "./host-applier.js";
@@ -83,6 +84,8 @@ export class BeautiSession {
    * Independent of fish mode. Re-asserted after publish / blob attach.
    */
   private videoMuted = true;
+  /** CSS overlay preference; process-local and dark by default for compatibility. */
+  private backgroundTone: BackgroundTone = "dark";
   /**
    * Saved theme currently bound for continuous video-progress writes.
    * Set on useSavedTheme; cleared when the user applies a different media path
@@ -300,6 +303,7 @@ export class BeautiSession {
         if (!this.videoMuted || input.type === "video") {
           await this.host.setMuted(this.videoMuted).catch(() => null);
         }
+        await this.reassertBackgroundTone();
       }
       return result;
     } finally {
@@ -314,6 +318,7 @@ export class BeautiSession {
     mediaServer: string | null;
     fish: boolean;
     muted: boolean;
+    tone: BackgroundTone;
   }> {
     await this.store.init();
     const manifest = await this.store.readActiveManifest();
@@ -325,6 +330,7 @@ export class BeautiSession {
         this.media.activeImage?.url ?? this.media.activeVideo?.url ?? null,
       fish: this.fishMode,
       muted: this.videoMuted,
+      tone: this.backgroundTone,
     };
   }
 
@@ -433,6 +439,42 @@ export class BeautiSession {
     }
     const result = await this.host.setMuted(this.videoMuted);
     if (result.ok) this.videoMuted = result.muted;
+    return result;
+  }
+
+  /** Change only the injected CSS overlay; media and generation are untouched. */
+  async setBackgroundTone(tone: BackgroundTone): Promise<{
+    ok: boolean;
+    tone: BackgroundTone;
+    sessions: number;
+    error?: string;
+  }> {
+    if (this.closed || !this.releaseLock) {
+      return {
+        ok: false,
+        tone: this.backgroundTone,
+        sessions: 0,
+        error: "Session is not started",
+      };
+    }
+    this.backgroundTone =
+      tone === "light" || tone === "auto" ? tone : "dark";
+    try {
+      await this.ensureHost({ allowDiscover: true });
+    } catch (err) {
+      // Keep the preference for the next Codex connection.
+      return {
+        ok: true,
+        tone: this.backgroundTone,
+        sessions: 0,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+    if (!this.host || !this.host.setBackgroundTone) {
+      return { ok: true, tone: this.backgroundTone, sessions: 0 };
+    }
+    const result = await this.host.setBackgroundTone(this.backgroundTone);
+    if (result.ok) this.backgroundTone = result.tone;
     return result;
   }
 
@@ -596,6 +638,7 @@ export class BeautiSession {
       if (!this.videoMuted || saved.input.type === "video") {
         await this.host.setMuted(this.videoMuted).catch(() => null);
       }
+      await this.reassertBackgroundTone();
       return result;
     } catch (err) {
       return {
@@ -803,6 +846,7 @@ export class BeautiSession {
       await this.host.apply(
         await buildHostApplyPayload(this.store, manifest, null, cssText),
       );
+      await this.reassertBackgroundTone();
       await this.media.commit(null);
       return;
     }
@@ -866,6 +910,12 @@ export class BeautiSession {
       await this.host.setFishMode(true).catch(() => null);
     }
     await this.host.setMuted(this.videoMuted).catch(() => null);
+    await this.reassertBackgroundTone();
+  }
+
+  private async reassertBackgroundTone(): Promise<void> {
+    if (!this.host?.setBackgroundTone) return;
+    await this.host.setBackgroundTone(this.backgroundTone).catch(() => null);
   }
 
   private assertOpenable(): void {

--- a/packages/adapter-codex/test/adapter.test.js
+++ b/packages/adapter-codex/test/adapter.test.js
@@ -723,6 +723,10 @@ test("fish mode CSS and runtime expose data-bc-fish helpers", async () => {
   assert.match(runtime, /setMuted/);
   assert.match(runtime, /isMuted/);
   assert.match(runtime, /applyMutePreference/);
+  assert.match(css, /data-bc-tone/);
+  assert.match(css, /prefers-color-scheme: light/);
+  assert.match(runtime, /setBackgroundTone/);
+  assert.match(runtime, /data-bc-tone/);
   assert.match(runtime, /getPlaybackPosition/);
   assert.match(runtime, /seekTo/);
   assert.match(runtime, /startAt/);
@@ -769,6 +773,44 @@ test("BeautiSession video mute defaults on and toggles without rebuild", async (
     assert.equal(session.isVideoMuted, true);
     const st1 = await session.status();
     assert.equal(st1.muted, true);
+  } finally {
+    await session.stop();
+    await mock.close();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test("BeautiSession background tone changes CSS only and survives publish", async () => {
+  const mock = await startMockCdp();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bc-tone-"));
+  const png = Buffer.from(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c63000100000500010d0a2db40000000049454e44ae426082",
+    "hex",
+  );
+  const imagePath = path.join(root, "a.png");
+  await fs.writeFile(imagePath, png);
+  const session = new BeautiSession({
+    port: mock.port,
+    dataRoot: path.join(root, "data"),
+    verifyDeadlineMs: 5_000,
+    pollMs: 200,
+    autoDiscover: false,
+    deferHostConnect: false,
+  });
+  try {
+    await session.start();
+    const applied = await session.apply({ type: "image", imagePath });
+    assert.equal(applied.ok, true, applied.ok ? "" : applied.error);
+    const generation = applied.generation;
+
+    const light = await session.setBackgroundTone("light");
+    assert.equal(light.ok, true, light.ok ? "" : light.error);
+    assert.equal(light.tone, "light");
+    const auto = await session.setBackgroundTone("auto");
+    assert.equal(auto.ok, true, auto.ok ? "" : auto.error);
+    const status = await session.status();
+    assert.equal(status.tone, "auto");
+    assert.equal(status.manifest.generation, generation);
   } finally {
     await session.stop();
     await mock.close();

--- a/packages/adapter-codex/test/adapter.test.js
+++ b/packages/adapter-codex/test/adapter.test.js
@@ -725,6 +725,13 @@ test("fish mode CSS and runtime expose data-bc-fish helpers", async () => {
   assert.match(runtime, /applyMutePreference/);
   assert.match(css, /data-bc-tone/);
   assert.match(css, /prefers-color-scheme: light/);
+  // Codex's main-surface class is CSS-module hashed and changes between builds.
+  assert.match(css, /body > #root main/);
+  assert.match(
+    css,
+    /body > #root main \{\s*position:\s*relative !important;\s*background-color:\s*transparent !important;/,
+  );
+  assert.doesNotMatch(css, /main\.main-surface/);
   assert.match(runtime, /setBackgroundTone/);
   assert.match(runtime, /data-bc-tone/);
   assert.match(runtime, /getPlaybackPosition/);

--- a/packages/adapter-codex/test/adapter.test.js
+++ b/packages/adapter-codex/test/adapter.test.js
@@ -732,6 +732,9 @@ test("fish mode CSS and runtime expose data-bc-fish helpers", async () => {
     /body > #root main \{\s*position:\s*relative !important;\s*background-color:\s*transparent !important;/,
   );
   assert.doesNotMatch(css, /main\.main-surface/);
+  // Current Codex builds use a CSS-module hash for the main viewport's
+  // otherwise opaque top fade; keep the stable component-name fragment.
+  assert.match(css, /\[class\*="_MainContentTopFade_"\]/);
   assert.match(runtime, /setBackgroundTone/);
   assert.match(runtime, /data-bc-tone/);
   assert.match(runtime, /getPlaybackPosition/);

--- a/packages/adapter-codex/test/mock-cdp.js
+++ b/packages/adapter-codex/test/mock-cdp.js
@@ -14,6 +14,7 @@ export async function startMockCdp(opts = {}) {
     body: true,
     protocol: "app:",
     runtime: {},
+    tone: "dark",
     lastExpression: null,
   };
 
@@ -85,6 +86,11 @@ export async function startMockCdp(opts = {}) {
           return true;
         },
         isMuted: () => Boolean(s.mutedPref),
+        getBackgroundTone: () => s.tone,
+        setBackgroundTone: (tone) => {
+          s.tone = tone === "light" || tone === "auto" ? tone : "dark";
+          return true;
+        },
         setMuted: (muted) => {
           s.mutedPref = Boolean(muted);
           return {
@@ -184,6 +190,18 @@ export async function startMockCdp(opts = {}) {
       if (typeof api.setMuted !== "function") return null;
       const wantMuted = /\bsetMuted\(true\)/.test(expression);
       return api.setMuted(wantMuted);
+    }
+
+    // Background tone toggle (CSS attribute-only; no media rebuild).
+    if (
+      expression.includes("setBackgroundTone") &&
+      expression.includes("__BEAUTICODE_BG__") &&
+      expression.length < 1000
+    ) {
+      const api = s.runtime.__BEAUTICODE_BG__;
+      if (!api || typeof api.setBackgroundTone !== "function") return false;
+      const match = expression.match(/setBackgroundTone\("(dark|light|auto)"\)/);
+      return Boolean(api.setBackgroundTone(match ? match[1] : "dark"));
     }
 
     // Playback position / seek (short expressions).

--- a/packages/core/src/apply-transaction.ts
+++ b/packages/core/src/apply-transaction.ts
@@ -9,6 +9,7 @@ import {
   MediaServerController,
   type MediaAssetHandle,
 } from "./media-server.js";
+import { detectImageMime } from "./media-validation.js";
 import type {
   ApplyInput,
   ApplyResult,
@@ -338,6 +339,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
   ".webp": "image/webp",
+  ".avif": "image/avif",
   ".mp4": "video/mp4",
 };
 
@@ -353,7 +355,11 @@ export async function fileToDataUrl(
     );
   }
   const ext = path.extname(filePath).toLowerCase();
-  const mime = mimeOverride ?? MIME_BY_EXT[ext];
+  const detectedImage =
+    !mimeOverride && ext !== ".mp4"
+      ? detectImageMime(bytes.subarray(0, 64), ext, bytes.byteLength)
+      : null;
+  const mime = mimeOverride ?? detectedImage?.mime ?? MIME_BY_EXT[ext];
   if (!mime) {
     throw new Error(`Unsupported media extension for data URL: ${ext || "(none)"}`);
   }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -39,6 +39,7 @@ export const IMAGE_EXTENSIONS = Object.freeze([
   ".jpeg",
   ".png",
   ".webp",
+  ".avif",
 ] as const);
 
 export const VIDEO_EXTENSION = ".mp4";

--- a/packages/core/src/media-validation.ts
+++ b/packages/core/src/media-validation.ts
@@ -22,6 +22,34 @@ function isWebp(buf: Buffer): boolean {
   );
 }
 
+/** AVIF is an ISO-BMFF image. Some downloaders save it with a .png suffix. */
+export function isAvifContainer(
+  bytes: Uint8Array,
+  totalSize: number = bytes?.byteLength ?? 0,
+): boolean {
+  if (!(bytes instanceof Uint8Array) || bytes.length < 16) return false;
+  const view = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const firstBoxSize = view.readUInt32BE(0);
+  if (
+    firstBoxSize < 16 ||
+    firstBoxSize > totalSize ||
+    view.subarray(4, 8).toString("ascii") !== "ftyp"
+  ) {
+    return false;
+  }
+  const brands = [view.subarray(8, 12)];
+  for (
+    let offset = 16;
+    offset + 4 <= Math.min(firstBoxSize, view.length);
+    offset += 4
+  ) {
+    brands.push(view.subarray(offset, offset + 4));
+  }
+  return brands.some(
+    (brand) => brand.toString("ascii") === "avif" || brand.toString("ascii") === "avis",
+  );
+}
+
 export class MediaValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -150,9 +178,10 @@ async function inspectAndHash(
   }
 }
 
-function detectImage(
+export function detectImageMime(
   buf: Buffer,
   extension: string,
+  totalSize: number = buf.byteLength,
 ): { mime: string } | null {
   if (buf.length >= 3 && buf.subarray(0, 3).equals(JPEG_MAGIC)) {
     if (extension === ".jpg" || extension === ".jpeg") {
@@ -167,6 +196,14 @@ function detectImage(
   }
   if (isWebp(buf)) {
     if (extension === ".webp") return { mime: "image/webp" };
+    return null;
+  }
+  // Keep compatibility with files such as the supplied "*.png" whose
+  // contents are AVIF. Do not make unrelated JPEG/PNG/WebP mismatches valid.
+  if (isAvifContainer(buf, totalSize)) {
+    if (extension === ".avif" || extension === ".png") {
+      return { mime: "image/avif" };
+    }
     return null;
   }
   return null;
@@ -190,10 +227,10 @@ export async function validateImageFile(
     );
   }
   const inspected = await inspectAndHash(resolved, size);
-  const detected = detectImage(inspected.head, ext);
+  const detected = detectImageMime(inspected.head, ext, size);
   if (!detected) {
     throw new MediaValidationError(
-      "Image content does not match a supported JPEG/PNG/WEBP signature.",
+      "Image content does not match a supported JPEG/PNG/WEBP/AVIF signature.",
     );
   }
   return {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -90,6 +90,8 @@ export async function ensureDataLayout(paths: DataPaths): Promise<void> {
       entry === SNAPSHOTS_DIR_NAME ||
       entry === SAVED_DIR_NAME ||
       entry === RUNTIME_MEDIA_DIR_NAME ||
+      entry === "logs" ||
+      entry === "engine-launcher.log" ||
       entry === "injector.lock" ||
       entry === "store.lock" ||
       entry === ".beauticode-commit.json" ||

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import { SCHEMA_ID } from "./constants.js";
 
 export type BackgroundType = "image" | "video" | "clear";
+export type BackgroundTone = "dark" | "light" | "auto";
 
 export interface BackgroundMedia {
   type: "image" | "video";
@@ -68,6 +69,13 @@ export interface VerifyResult {
 
 export interface HostApplier {
   apply(payload: HostApplyPayload): Promise<void>;
+  /** Optional to keep custom/older host implementations source-compatible. */
+  setBackgroundTone?(tone: BackgroundTone): Promise<{
+    ok: boolean;
+    tone: BackgroundTone;
+    sessions: number;
+    error?: string;
+  }>;
   verify(
     expected: VerifyExpectation,
     opts: { deadlineMs: number },

--- a/packages/core/test/background-store.test.js
+++ b/packages/core/test/background-store.test.js
@@ -583,6 +583,23 @@ test("data root ownership adopts a valid legacy active manifest", async () => {
   await fs.rm(root, { recursive: true, force: true });
 });
 
+test("data root tolerates launcher logs created before the ownership marker", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bc-root-log-"));
+  await fs.writeFile(path.join(root, "engine-launcher.log"), "old launcher\n", "utf8");
+  await fs.mkdir(path.join(root, "logs"));
+  await fs.writeFile(path.join(root, "logs", "tray.log"), "old tray\n", "utf8");
+
+  const store = new BackgroundStore({ root });
+  const manifest = await store.readActiveManifest();
+  assert.equal(manifest.background, null);
+  assert.equal(
+    JSON.parse(await fs.readFile(path.join(root, ".beauticode-root.json"), "utf8")).schema,
+    "beauticode.data-root/v1",
+  );
+
+  await fs.rm(root, { recursive: true, force: true });
+});
+
 test("saved theme quota and deletion are enforced", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "bc-theme-quota-"));
   const fixtures = path.join(root, "fixtures");

--- a/packages/core/test/media-validation.test.js
+++ b/packages/core/test/media-validation.test.js
@@ -4,8 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { MAX_VIDEO_BYTES } from "../dist/constants.js";
+import { fileToDataUrl } from "../dist/apply-transaction.js";
 import {
   assertSafeBasename,
+  isAvifContainer,
   isMp4Container,
   MediaValidationError,
   validateImageFile,
@@ -31,11 +33,43 @@ function pngFixture() {
   );
 }
 
+function avifFixture() {
+  const fileTypeBox = Buffer.alloc(24);
+  fileTypeBox.writeUInt32BE(fileTypeBox.length, 0);
+  fileTypeBox.write("ftyp", 4, "ascii");
+  fileTypeBox.write("avif", 8, "ascii");
+  fileTypeBox.writeUInt32BE(0, 12);
+  fileTypeBox.write("avif", 16, "ascii");
+  fileTypeBox.write("mif1", 20, "ascii");
+  return Buffer.concat([fileTypeBox, Buffer.from("AV1PAYLOAD", "ascii")]);
+}
+
 test("isMp4Container accepts ftyp and rejects junk", () => {
   const ok = mp4Fixture();
   assert.equal(isMp4Container(ok, ok.length), true);
   assert.equal(isMp4Container(Buffer.from("not-an-mp4"), 10), false);
   assert.equal(isMp4Container(Buffer.alloc(8), 8), false);
+});
+
+test("AVIF detection accepts .avif and a mislabeled .png", async () => {
+  const bytes = avifFixture();
+  assert.equal(isAvifContainer(bytes, bytes.length), true);
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bc-avif-"));
+  try {
+    for (const name of ["actual.avif", "downloaded.png"]) {
+      const file = path.join(root, name);
+      await fs.writeFile(file, bytes);
+      const image = await validateImageFile(file);
+      assert.equal(image.mime, "image/avif");
+      const dataUrl = await fileToDataUrl(file);
+      assert.match(dataUrl, /^data:image\/avif;base64,/);
+    }
+    const wrongExt = path.join(root, "wrong.jpg");
+    await fs.writeFile(wrongExt, bytes);
+    await assert.rejects(() => validateImageFile(wrongExt), /signature/);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
 });
 
 test("validateVideoFile enforces extension, size, ftyp, no symlink", async () => {

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -207,6 +207,7 @@ foreach ($relativeFile in @(
     "apps\tray\session-host.mjs",
     "apps\tray\start-tray.ps1",
     "assets\beauticode-icon-borderless.png",
+    "scripts\codex-launch.ps1",
     "scripts\start-beauticode-engine.ps1",
     "packages\core\package.json",
     "packages\adapter-codex\package.json",

--- a/scripts/codex-launch.ps1
+++ b/scripts/codex-launch.ps1
@@ -1,0 +1,174 @@
+# Shared Windows Codex discovery and loopback launch helpers.
+# This file is dot-sourced by both the one-click launcher and the tray process.
+
+$script:BeautiCodeKnownCodexAppUserModelId = "OpenAI.Codex_2p2nqsd0c76g0!App"
+
+function Get-BcCodexMainProcesses {
+  foreach ($process in @(Get-Process -Name "ChatGPT", "Codex" -ErrorAction SilentlyContinue)) {
+    $path = $null
+    try { $path = $process.Path } catch { }
+    if (-not $path) { continue }
+    $leaf = [System.IO.Path]::GetFileName($path)
+    if ($leaf -notmatch "^(ChatGPT|Codex)\.exe$") { continue }
+    if ($path -match "\\resources\\") { continue }
+    [pscustomobject]@{
+      Process = $process
+      Path = $path
+    }
+  }
+}
+
+function Get-BcCodexPackageLocations {
+  $packages = @()
+  try {
+    $packages += @(Get-AppxPackage -Name "*OpenAI.Codex*" -ErrorAction SilentlyContinue)
+  } catch { }
+  if ($packages.Count -eq 0) {
+    try {
+      $packages += @(
+        Get-AppxPackage -ErrorAction SilentlyContinue |
+          Where-Object {
+            $_.Name -match "OpenAI\.Codex|ChatGPT" -or
+            $_.PackageFamilyName -match "OpenAI\.Codex|ChatGPT"
+          }
+      )
+    } catch { }
+  }
+  $packages |
+    Where-Object { $_.InstallLocation } |
+    Sort-Object -Property Version -Descending |
+    ForEach-Object { [string]$_.InstallLocation } |
+    Select-Object -Unique
+}
+
+function Find-BcCodexExecutable {
+  $candidates = New-Object System.Collections.ArrayList
+
+  foreach ($running in @(Get-BcCodexMainProcesses)) {
+    [void]$candidates.Add($running.Path)
+  }
+
+  foreach ($installLocation in @(Get-BcCodexPackageLocations)) {
+    foreach ($relative in @(
+        "app\ChatGPT.exe",
+        "app\Codex.exe",
+        "ChatGPT.exe",
+        "Codex.exe"
+      )) {
+      [void]$candidates.Add((Join-Path $installLocation $relative))
+    }
+  }
+
+  foreach ($root in @($env:LOCALAPPDATA, $env:ProgramFiles, ${env:ProgramFiles(x86)})) {
+    if (-not $root) { continue }
+    foreach ($relative in @(
+        "Programs\ChatGPT\ChatGPT.exe",
+        "Programs\chatgpt\ChatGPT.exe",
+        "Programs\Codex\Codex.exe",
+        "Programs\codex\Codex.exe",
+        "OpenAI\ChatGPT\ChatGPT.exe",
+        "OpenAI\Codex\Codex.exe"
+      )) {
+      [void]$candidates.Add((Join-Path $root $relative))
+    }
+  }
+
+  foreach ($candidate in @($candidates)) {
+    if (-not $candidate) { continue }
+    try {
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $candidate).Path
+      }
+    } catch { }
+  }
+  return $null
+}
+
+function Find-BcCodexAppUserModelId {
+  try {
+    $startApps = @(
+      Get-StartApps -ErrorAction SilentlyContinue |
+        Where-Object {
+          $_.AppID -and ($_.Name -match "Codex|ChatGPT|OpenAI")
+        }
+    )
+    if ($startApps.Count -gt 0) {
+      return [string]$startApps[0].AppID
+    }
+  } catch { }
+  return $script:BeautiCodeKnownCodexAppUserModelId
+}
+
+function Test-BcLoopbackPortAvailable([int]$Port) {
+  if ($Port -lt 1 -or $Port -gt 65535) { return $false }
+  $listener = $null
+  try {
+    $listener = New-Object System.Net.Sockets.TcpListener(
+      [System.Net.IPAddress]::Loopback,
+      $Port
+    )
+    $listener.Start()
+    return $true
+  } catch {
+    return $false
+  } finally {
+    if ($null -ne $listener) {
+      try { $listener.Stop() } catch { }
+    }
+  }
+}
+
+function Get-BcLoopbackCdpPort([int]$Preferred = 9335) {
+  if (Test-BcLoopbackPortAvailable -Port $Preferred) {
+    return $Preferred
+  }
+  $listener = $null
+  try {
+    $listener = New-Object System.Net.Sockets.TcpListener(
+      [System.Net.IPAddress]::Loopback,
+      0
+    )
+    $listener.Start()
+    return [int]$listener.LocalEndpoint.Port
+  } finally {
+    if ($null -ne $listener) {
+      try { $listener.Stop() } catch { }
+    }
+  }
+}
+
+function Start-BcCodexWithCdp([int]$CdpPort = 9335) {
+  if ($CdpPort -le 0 -or $CdpPort -gt 65535) {
+    $CdpPort = Get-BcLoopbackCdpPort
+  }
+  $executable = Find-BcCodexExecutable
+  if ($executable) {
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $executable
+    $psi.Arguments = "--remote-debugging-address=127.0.0.1 --remote-debugging-port=$CdpPort"
+    $psi.WorkingDirectory = Split-Path -Parent $executable
+    $psi.UseShellExecute = $true
+    [void][System.Diagnostics.Process]::Start($psi)
+    return [pscustomobject]@{
+      Method = "executable"
+      Executable = $executable
+      AppUserModelId = $null
+      Port = $CdpPort
+    }
+  }
+
+  $appUserModelId = Find-BcCodexAppUserModelId
+  if ($appUserModelId) {
+    Start-Process -FilePath "explorer.exe" `
+      -ArgumentList ("shell:AppsFolder\{0}" -f $appUserModelId) `
+      -ErrorAction Stop | Out-Null
+    return [pscustomobject]@{
+      Method = "appx"
+      Executable = $null
+      AppUserModelId = $appUserModelId
+      Port = $CdpPort
+    }
+  }
+
+  throw "Cannot find an installed Codex/ChatGPT Desktop application. Install Codex Desktop first."
+}

--- a/scripts/start-beauticode-engine.ps1
+++ b/scripts/start-beauticode-engine.ps1
@@ -145,7 +145,7 @@ function Get-CodexMainExeFast {
   return Find-BcCodexExecutable
 }
 
-function Confirm-BcRestartCodex {
+function Confirm-BcCodexAction {
   param([string]$Text)
   try {
     Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
@@ -242,6 +242,7 @@ try {
     throw "Missing tray script: $TrayScript"
   }
 
+  $trayAlreadyRunning = $false
   if ($ForceRestart) {
     foreach ($procId in @(Get-BcTrayPids)) {
       try { Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue } catch {}
@@ -250,9 +251,10 @@ try {
   } else {
     # The tray owns this process-lifetime mutex. Checking it avoids the
     # 0.3-1.0s Win32_Process scan on every normal launch.
-    if (Test-BcTrayRunningFast) {
-      Write-BcLog "engine already running mutex=True"
-      # No modal dialog — tray icon is already the signal. Exit quietly.
+    $trayAlreadyRunning = Test-BcTrayRunningFast
+    if ($trayAlreadyRunning -and $NoLaunchCodex) {
+      Write-BcLog "engine already running mutex=True NoLaunchCodex=True"
+      # Windows logon startup stays silent and never opens/restarts Codex.
       exit 0
     }
   }
@@ -285,8 +287,12 @@ try {
   } else {
     0
   }
-  Start-BcTray -CdpPort $trayPort
-  Write-BcLog ("tray spawned in {0}ms" -f $sw.ElapsedMilliseconds)
+  if ($trayAlreadyRunning) {
+    Write-BcLog "engine already running mutex=True - checking Codex match"
+  } else {
+    Start-BcTray -CdpPort $trayPort
+    Write-BcLog ("tray spawned in {0}ms" -f $sw.ElapsedMilliseconds)
+  }
 
   # 3) If no CDP, kick Codex launch after the tray process is already running.
   #    The session-host watch loop attaches when CDP appears.
@@ -295,11 +301,13 @@ try {
       # A normal Codex launch may not expose CDP. Never kill it silently:
       # ask once, close gracefully, then relaunch with loopback CDP so the
       # session-host watcher can import the active background immediately.
-      $accepted = Confirm-BcRestartCodex -Text "Codex is already running without a reachable CDP endpoint.`n`nTo let beautiCode detect Codex and import the active background immediately, Codex must restart safely. Unsaved content may be lost. Continue?"
+      $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex is already running without a reachable CDP endpoint.`n`nTo let beautiCode match this window and restore the active background, ChatGPT/Codex must restart safely. Unsaved content may be lost. Restart now?"
       if ($accepted) {
         Write-BcLog "no CDP and Codex already running - user accepted graceful restart"
         if (Stop-BcCodexGracefully) {
-          [void](Start-CodexWithCdpFast -CdpPort $launchPort)
+          if (-not (Start-CodexWithCdpFast -CdpPort $launchPort)) {
+            Show-BcMessage -Icon "Error" -Text "ChatGPT/Codex could not be reopened with a local CDP endpoint. Check the beautiCode launcher log and try again."
+          }
         } else {
           Write-BcLog "Codex graceful restart stopped: process did not exit"
           Show-BcMessage -Icon "Warning" -Text "Codex did not exit safely within the timeout. beautiCode did not force-close it. Use the tray action Apply or reapply to try again."
@@ -308,8 +316,15 @@ try {
         Write-BcLog "no CDP and Codex already running - user declined restart"
       }
     } else {
-      Write-BcLog "no CDP yet - launching Codex after tray spawn"
-      [void](Start-CodexWithCdpFast -CdpPort $launchPort)
+      $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex is not running.`n`nOpen it with a local CDP endpoint so beautiCode can match the window and restore the active background?"
+      if ($accepted) {
+        Write-BcLog "no CDP and Codex not running - user accepted launch"
+        if (-not (Start-CodexWithCdpFast -CdpPort $launchPort)) {
+          Show-BcMessage -Icon "Error" -Text "ChatGPT/Codex could not be opened with a local CDP endpoint. Check the beautiCode launcher log and try again."
+        }
+      } else {
+        Write-BcLog "no CDP and Codex not running - user declined launch"
+      }
     }
   }
 

--- a/scripts/start-beauticode-engine.ps1
+++ b/scripts/start-beauticode-engine.ps1
@@ -11,7 +11,7 @@
   - If Codex is missing, launch it in parallel while the tray comes up
 #>
 param(
-  [int]$Port = 9335,
+  [int]$Port = 0,
   [switch]$ForceRestart,
   [switch]$NoLaunchCodex
 )
@@ -22,10 +22,20 @@ if ($Port -lt 0 -or $Port -gt 65535) {
 }
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $TrayScript = Join-Path $RepoRoot "apps\tray\start-tray.ps1"
+$CodexLaunchScript = Join-Path $RepoRoot "scripts\codex-launch.ps1"
 $ReleaseManifest = Join-Path $RepoRoot "release-manifest.json"
-$CodexAppUserModelId = "OpenAI.Codex_2p2nqsd0c76g0!App"
-$LogPath = Join-Path $env:LOCALAPPDATA "beautiCode\engine-launcher.log"
+$LogRoot = if ($env:LOCALAPPDATA) {
+  Join-Path $env:LOCALAPPDATA "beautiCode\logs"
+} else {
+  Join-Path ([System.IO.Path]::GetTempPath()) "beautiCode\logs"
+}
+$LogPath = Join-Path $LogRoot "engine-launcher.log"
 $TrayMutexName = "Local\beautiCode.Engine.Tray.v1"
+
+if (-not (Test-Path -LiteralPath $CodexLaunchScript -PathType Leaf)) {
+  throw "Missing Codex launch helper: $CodexLaunchScript"
+}
+. $CodexLaunchScript
 
 function Write-BcLog([string]$Message) {
   try {
@@ -132,49 +142,59 @@ function Get-BcTrayPids {
 }
 
 function Get-CodexMainExeFast {
-  # Avoid scanning all processes on every launch. Prefer AppX path, then known installs.
-  try {
-    $pkg = Get-AppxPackage -Name "OpenAI.Codex" -ErrorAction SilentlyContinue |
-      Sort-Object -Property Version -Descending |
-      Select-Object -First 1
-    if ($pkg -and $pkg.InstallLocation) {
-      $candidate = Join-Path $pkg.InstallLocation "app\ChatGPT.exe"
-      if (Test-Path -LiteralPath $candidate) { return $candidate }
-    }
-  } catch {}
+  return Find-BcCodexExecutable
+}
 
-  foreach ($p in @(
-      (Join-Path $env:LOCALAPPDATA "Programs\chatgpt\ChatGPT.exe"),
-      (Join-Path $env:LOCALAPPDATA "Programs\Codex\Codex.exe")
-    )) {
-    if ($p -and (Test-Path -LiteralPath $p)) { return $p }
+function Confirm-BcRestartCodex {
+  param([string]$Text)
+  try {
+    Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+    $result = [System.Windows.Forms.MessageBox]::Show(
+      $Text,
+      "beautiCode",
+      [System.Windows.Forms.MessageBoxButtons]::YesNo,
+      [System.Windows.Forms.MessageBoxIcon]::Warning,
+      [System.Windows.Forms.MessageBoxDefaultButton]::Button2
+    )
+    return $result -eq [System.Windows.Forms.DialogResult]::Yes
+  } catch {
+    return $false
   }
-  return $null
+}
+
+function Stop-BcCodexGracefully([int]$WaitSeconds = 8) {
+  $targets = @(Get-BcCodexMainProcesses)
+  foreach ($target in $targets) {
+    try {
+      if ($target.Process.MainWindowHandle -ne [IntPtr]::Zero) {
+        [void]$target.Process.CloseMainWindow()
+      }
+    } catch {
+      Write-BcLog ("could not request graceful Codex close: {0}" -f $_.Exception.Message)
+    }
+  }
+  $deadline = [datetime]::UtcNow.AddSeconds([Math]::Max(1, $WaitSeconds))
+  do {
+    if (@(Get-BcCodexMainProcesses).Count -eq 0) { return $true }
+    Start-Sleep -Milliseconds 250
+  } while ([datetime]::UtcNow -lt $deadline)
+  return (@(Get-BcCodexMainProcesses).Count -eq 0)
 }
 
 function Start-CodexWithCdpFast([int]$CdpPort) {
-  if ($CdpPort -le 0 -or $CdpPort -gt 65535) { $CdpPort = 9335 }
-  $exe = Get-CodexMainExeFast
-  $args = ("--remote-debugging-address=127.0.0.1 --remote-debugging-port={0}" -f $CdpPort)
-  if ($exe) {
-    try {
-      $psi = New-Object System.Diagnostics.ProcessStartInfo
-      $psi.FileName = $exe
-      $psi.Arguments = $args
-      $psi.UseShellExecute = $true
-      [void][System.Diagnostics.Process]::Start($psi)
-      Write-BcLog ("started Codex exe={0} port={1}" -f $exe, $CdpPort)
-      return $true
-    } catch {
-      Write-BcLog ("direct Codex start failed: {0}" -f $_.Exception.Message)
-    }
+  if ($CdpPort -le 0 -or $CdpPort -gt 65535) {
+    $CdpPort = Get-BcLoopbackCdpPort
   }
   try {
-    Start-Process -FilePath "explorer.exe" -ArgumentList ("shell:AppsFolder\{0}" -f $CodexAppUserModelId) | Out-Null
-    Write-BcLog "launched Codex via AppsFolder"
+    $result = Start-BcCodexWithCdp -CdpPort $CdpPort
+    if ($result.Method -eq "executable") {
+      Write-BcLog ("started Codex exe={0} port={1}" -f $result.Executable, $result.Port)
+    } else {
+      Write-BcLog ("launched Codex via AppsFolder appId={0}; custom CDP args may be ignored" -f $result.AppUserModelId)
+    }
     return $true
   } catch {
-    Write-BcLog ("AppsFolder launch failed: {0}" -f $_.Exception.Message)
+    Write-BcLog ("Codex launch failed: {0}" -f $_.Exception.Message)
     return $false
   }
 }
@@ -240,6 +260,18 @@ try {
   # 1) Fast CDP probe (preferred port only, ~100–300ms worst case miss).
   $cdpPort = Find-BcCdpPortFast -Preferred $Port
 
+  $codexExecutable = Get-CodexMainExeFast
+  $codexAlreadyRunning = (@(Get-BcCodexMainProcesses).Count -gt 0)
+  $launchPort = if ($cdpPort -gt 0) {
+    $cdpPort
+  } elseif ($Port -gt 0) {
+    $Port
+  } elseif ($codexExecutable -and -not $codexAlreadyRunning) {
+    Get-BcLoopbackCdpPort
+  } else {
+    0
+  }
+
   # 2) Spawn the tray before AppX lookup / Codex cold start. The session-host
   #    connects in the background, so neither task needs to block tray startup.
   #    Port 0 → session-host auto-discovers in background.
@@ -248,6 +280,8 @@ try {
     $cdpPort
   } elseif ($Port -gt 0) {
     $Port
+  } elseif ($launchPort -gt 0) {
+    $launchPort
   } else {
     0
   }
@@ -257,8 +291,26 @@ try {
   # 3) If no CDP, kick Codex launch after the tray process is already running.
   #    The session-host watch loop attaches when CDP appears.
   if ($cdpPort -le 0 -and -not $NoLaunchCodex) {
-    Write-BcLog "no CDP yet - launching Codex after tray spawn"
-    [void](Start-CodexWithCdpFast -CdpPort $Port)
+    if ($codexAlreadyRunning) {
+      # A normal Codex launch may not expose CDP. Never kill it silently:
+      # ask once, close gracefully, then relaunch with loopback CDP so the
+      # session-host watcher can import the active background immediately.
+      $accepted = Confirm-BcRestartCodex -Text "Codex is already running without a reachable CDP endpoint.`n`nTo let beautiCode detect Codex and import the active background immediately, Codex must restart safely. Unsaved content may be lost. Continue?"
+      if ($accepted) {
+        Write-BcLog "no CDP and Codex already running - user accepted graceful restart"
+        if (Stop-BcCodexGracefully) {
+          [void](Start-CodexWithCdpFast -CdpPort $launchPort)
+        } else {
+          Write-BcLog "Codex graceful restart stopped: process did not exit"
+          Show-BcMessage -Icon "Warning" -Text "Codex did not exit safely within the timeout. beautiCode did not force-close it. Use the tray action Apply or reapply to try again."
+        }
+      } else {
+        Write-BcLog "no CDP and Codex already running - user declined restart"
+      }
+    } else {
+      Write-BcLog "no CDP yet - launching Codex after tray spawn"
+      [void](Start-CodexWithCdpFast -CdpPort $launchPort)
+    }
   }
 
   $sw.Stop()


### PR DESCRIPTION
## What changed

- remove the opaque hashed `MainContentTopFade` layer that appeared as a black edge over active backgrounds
- keep the tray startup path silent for logon, while normal launches detect an already-running ChatGPT/Codex window and offer a safe CDP restart or launch
- include the outstanding reconnect, background tone, tray UI, and v0.1.1 packaging work added after PR #2 merged
- bump the self-contained Windows package and README download target to v0.1.2

## Why

Recent Codex builds moved the main viewport top fade behind a CSS-module hash, so the older stable selector no longer made that layer transparent. In addition, manually launched ChatGPT/Codex instances normally have no reachable CDP endpoint; beautiCode cannot attach until the app is reopened with loopback CDP enabled.

## Impact

Active image/video backgrounds no longer retain the opaque top edge on current Codex builds. A normal beautiCode launch can now guide users through matching an already-running ChatGPT/Codex instance without force-killing it. Windows logon startup remains non-interactive.

## Validation

- `npm.cmd test`: core 24/24, adapter 22/22
- `npm.cmd run typecheck`
- PowerShell 5.1 parser check for `scripts/start-beauticode-engine.ps1`
- `git diff --check`
- Windows installer built from clean commit `1edc827dc3c3`; release manifest reports `dirty: false`
- installer SHA-256: `96E3F77296E4FE7B59EDF336338E91895C8AAA4381BB3CC743FC428456238AA1`

## Limitations

The installer is unsigned. The interactive confirmation/restart path and a real renderer black-edge check were not run during this publish pass to avoid interrupting the active desktop session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增背景色调切换：支持深色、浅色和跟随系统，并可从托盘菜单调整。
  * 支持 AVIF 图片导入、识别和预览。
  * 改进 Windows 下 Codex 启动、连接与诊断流程。

* **改进**
  * 优化背景应用在会话重连后的状态保持。
  * 更新 Windows 安装包至 v0.1.2，并明确系统要求和故障排查信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->