### PR TITLE
release v0.1.3/v0.1.4 launcher reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ beautiCode 可以让你：
 > 不是逃离工作，而是给漫长的工作过程，留一点属于自己的空间。
 <img width="1920" height="1240" alt="QQ20260729-212506-HD" src="https://github.com/user-attachments/assets/ca0ef07f-2aec-46b0-b996-1db9913efa6d" />
 
-### v0.1.3 安装包
+### v0.1.4 安装包
 
-想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.3)。
+想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.4)。
 安装包自带运行时，不需要另外安装 Node.js 或 npm；使用前请先安装 Codex Desktop。
 
 
@@ -163,7 +163,7 @@ Ctrl + Shift + Space
 运行：
 
 ```text
-beautiCode-Setup-0.1.3-win-x64.exe
+beautiCode-Setup-0.1.4-win-x64.exe
 ```
 
 安装包自带 Node.js 运行时。使用者不需要安装 Node.js、npm，也不需要保留

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ beautiCode 可以让你：
 > 不是逃离工作，而是给漫长的工作过程，留一点属于自己的空间。
 <img width="1920" height="1240" alt="QQ20260729-212506-HD" src="https://github.com/user-attachments/assets/ca0ef07f-2aec-46b0-b996-1db9913efa6d" />
 
-### v0.1.2 安装包
+### v0.1.3 安装包
 
-想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.2)。
+想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.3)。
 安装包自带运行时，不需要另外安装 Node.js 或 npm；使用前请先安装 Codex Desktop。
 
 
@@ -163,7 +163,7 @@ Ctrl + Shift + Space
 运行：
 
 ```text
-beautiCode-Setup-0.1.2-win-x64.exe
+beautiCode-Setup-0.1.3-win-x64.exe
 ```
 
 安装包自带 Node.js 运行时。使用者不需要安装 Node.js、npm，也不需要保留

--- a/apps/tray/session-host.mjs
+++ b/apps/tray/session-host.mjs
@@ -29,7 +29,7 @@ import crypto from "node:crypto";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 if (Number(process.versions.node.split(".", 1)[0]) < 22) {
-  console.error("session-host requires Node.js 22 or newer");
+  console.error("session-host 需要 Node.js 22 或更高版本。");
   process.exit(1);
 }
 
@@ -52,16 +52,17 @@ const portArg = argValue("--port");
 const dataRoot = argValue("--data-root");
 const verifyMs = Number(argValue("--verify-ms") ?? "30000");
 if (!Number.isFinite(verifyMs) || verifyMs < 0 || verifyMs > 300_000) {
-  console.error("--verify-ms must be between 0 and 300000");
+  console.error("--verify-ms 必须在 0 到 300000 之间。");
   process.exit(1);
 }
 
 if (!token || token.length < 24) {
-  console.error("session-host requires a random control token (>=24 chars)");
+  console.error("session-host 需要长度至少为 24 个字符的随机控制令牌。");
   process.exit(1);
 }
 
 const adapter = await import(adapterEntry);
+const toChineseErrorMessage = adapter.toChineseErrorMessage;
 
 const sessionOpts = {
   verifyDeadlineMs: verifyMs,
@@ -69,7 +70,7 @@ const sessionOpts = {
   // Tray must show immediately; CDP connect + first publish happen in background.
   deferHostConnect: true,
   onError: (err) => {
-    console.error(`[session] ${err.message}`);
+    console.error(`[session] ${toChineseErrorMessage(err)}`);
   },
   onStatus: (msg) => {
     console.error(`[session] ${msg}`);
@@ -78,7 +79,7 @@ const sessionOpts = {
 if (portArg) {
   const p = Number(portArg);
   if (!Number.isInteger(p) || p < 1 || p > 65535) {
-    console.error("--port must be 1–65535");
+    console.error("--port 必须是 1–65535 之间的整数。");
     process.exit(1);
   }
   sessionOpts.port = p;
@@ -146,7 +147,11 @@ function publicTheme(theme) {
 
 function send(res, status, obj) {
   if (res.destroyed || res.writableEnded) return;
-  const body = JSON.stringify(obj);
+  const body = JSON.stringify(
+    obj && typeof obj.error === "string"
+      ? { ...obj, error: toChineseErrorMessage(obj.error) }
+      : obj,
+  );
   res.writeHead(status, {
     "Content-Type": "application/json; charset=utf-8",
     "Cache-Control": "no-store",
@@ -156,7 +161,7 @@ function send(res, status, obj) {
 }
 
 function unauthorized(res) {
-  send(res, 401, { ok: false, error: "unauthorized" });
+  send(res, 401, { ok: false, error: "请求未授权。" });
 }
 
 function checkAuth(req) {
@@ -179,7 +184,7 @@ const server = http.createServer(
       return;
     }
     if (shuttingDown) {
-      send(res, 503, { ok: false, error: "shutting down" });
+      send(res, 503, { ok: false, error: "服务正在关闭。" });
       return;
     }
     const url = req.url?.split("?")[0] ?? "";
@@ -222,7 +227,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/apply/image") {
       const body = await readBody(req);
       if (typeof body.imagePath !== "string" || !body.imagePath) {
-        send(res, 400, { ok: false, error: "imagePath required" });
+        send(res, 400, { ok: false, error: "必须提供 imagePath。" });
         return;
       }
       const result = await session.apply({
@@ -237,7 +242,7 @@ const server = http.createServer(
       if (typeof body.videoPath !== "string" || !body.videoPath) {
         send(res, 400, {
           ok: false,
-          error: "videoPath required (MP4). imagePath optional poster.",
+          error: "必须提供 videoPath（MP4）；imagePath 可选，用作海报图片。",
         });
         return;
       }
@@ -265,7 +270,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/theme/save") {
       const body = await readBody(req);
       if (typeof body.name !== "string" || !body.name.trim()) {
-        send(res, 400, { ok: false, error: "name required" });
+        send(res, 400, { ok: false, error: "必须提供主题名称。" });
         return;
       }
       try {
@@ -274,7 +279,7 @@ const server = http.createServer(
       } catch (err) {
         send(res, 422, {
           ok: false,
-          error: err instanceof Error ? err.message : String(err),
+          error: toChineseErrorMessage(err),
         });
       }
       return;
@@ -287,7 +292,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/theme/use") {
       const body = await readBody(req);
       if (typeof body.id !== "string" || !body.id.trim()) {
-        send(res, 400, { ok: false, error: "id required" });
+        send(res, 400, { ok: false, error: "必须提供主题 ID。" });
         return;
       }
       const result = await session.useSavedTheme(body.id.trim());
@@ -297,7 +302,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/theme/delete") {
       const body = await readBody(req);
       if (typeof body.id !== "string" || !body.id.trim()) {
-        send(res, 400, { ok: false, error: "id required" });
+        send(res, 400, { ok: false, error: "必须提供主题 ID。" });
         return;
       }
       try {
@@ -305,13 +310,13 @@ const server = http.createServer(
         send(res, deleted ? 200 : 404, {
           ok: deleted,
           deleted,
-          ...(deleted ? {} : { error: "Saved theme not found." }),
+          ...(deleted ? {} : { error: "未找到已保存的主题。" }),
         });
       } catch (err) {
         send(res, 422, {
           ok: false,
           deleted: false,
-          error: err instanceof Error ? err.message : String(err),
+          error: toChineseErrorMessage(err),
         });
       }
       return;
@@ -319,7 +324,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/mode/fish") {
       const body = await readBody(req);
       if (typeof body.enabled !== "boolean") {
-        send(res, 400, { ok: false, error: "enabled boolean required" });
+        send(res, 400, { ok: false, error: "enabled 必须是布尔值。" });
         return;
       }
       const result = await session.setFishMode(body.enabled);
@@ -329,7 +334,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/mode/muted") {
       const body = await readBody(req);
       if (typeof body.muted !== "boolean") {
-        send(res, 400, { ok: false, error: "muted boolean required" });
+        send(res, 400, { ok: false, error: "muted 必须是布尔值。" });
         return;
       }
       const result = await session.setMuted(body.muted);
@@ -339,7 +344,7 @@ const server = http.createServer(
     if (req.method === "POST" && url === "/mode/tone") {
       const body = await readBody(req);
       if (!["dark", "light", "auto"].includes(body.tone)) {
-        send(res, 400, { ok: false, error: "tone must be dark, light, or auto" });
+        send(res, 400, { ok: false, error: "tone 必须是 dark、light 或 auto。" });
         return;
       }
       const result = await session.setBackgroundTone(body.tone);
@@ -351,7 +356,7 @@ const server = http.createServer(
       setImmediate(() => void shutdown(0));
       return;
     }
-    send(res, 404, { ok: false, error: "not found" });
+    send(res, 404, { ok: false, error: "未找到请求的资源。" });
   } catch (err) {
     const status =
       err && typeof err === "object" && Number.isInteger(err.statusCode)
@@ -359,7 +364,7 @@ const server = http.createServer(
         : 500;
     send(res, status, {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: toChineseErrorMessage(err),
     });
   }
   },
@@ -388,9 +393,9 @@ try {
   await session.start();
 } catch (err) {
   console.error(
-    err instanceof Error ? err.message : String(err),
+    toChineseErrorMessage(err),
   );
-  console.error("session-host: failed to start BeautiSession (fail closed)");
+  console.error("session-host：beautiCode 会话启动失败，已安全退出。");
   process.exit(1);
 }
 

--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -44,6 +44,8 @@ Write-BcTrayLog "tray starting"
 
 $script:trayInstanceMutex = $null
 $script:trayInstanceMutexOwned = $false
+$script:showPanelEvent = $null
+$script:showPanelTimer = $null
 $createdNew = $false
 $script:trayInstanceMutex = [System.Threading.Mutex]::new(
   $true,
@@ -55,6 +57,13 @@ if (-not $createdNew) {
   exit 0
 }
 $script:trayInstanceMutexOwned = $true
+$showPanelEventCreated = $false
+$script:showPanelEvent = [System.Threading.EventWaitHandle]::new(
+  $false,
+  [System.Threading.EventResetMode]::AutoReset,
+  "Local\beautiCode.Engine.ShowPanel.v1",
+  [ref]$showPanelEventCreated
+)
 
 $dpiNativeCode = @'
 using System;
@@ -222,13 +231,13 @@ $coreDist = Join-Path $RepoRoot "packages\core\dist\index.js"
 $adapterDist = Join-Path $RepoRoot "packages\adapter-codex\dist\index.js"
 
 if (-not (Test-Path -LiteralPath $CodexLaunchScript -PathType Leaf)) {
-  throw "Missing Codex launch helper: $CodexLaunchScript"
+  throw "缺少 Codex 启动脚本：$CodexLaunchScript"
 }
 . $CodexLaunchScript
 
 if ($NodePath) {
   if (-not (Test-Path -LiteralPath $NodePath -PathType Leaf)) {
-    throw ("Node executable not found: {0}" -f $NodePath)
+    throw ("未找到 Node.js 可执行文件：{0}" -f $NodePath)
   }
   $Node = (Resolve-Path -LiteralPath $NodePath).Path
 } elseif (Test-Path -LiteralPath $BundledNode -PathType Leaf) {
@@ -242,7 +251,7 @@ if (Test-Path -LiteralPath $ReleaseManifest -PathType Leaf) {
 }
 
 if (-not (Test-Path -LiteralPath $HostScript)) {
-  throw ("Missing session-host.mjs at {0}" -f $HostScript)
+  throw ("未找到 session-host.mjs：{0}" -f $HostScript)
 }
 
 if (-not $SkipBuild) {
@@ -283,7 +292,7 @@ if (-not $SkipBuild) {
     try {
       & npm.cmd run build
       if ($LASTEXITCODE -ne 0) {
-        throw ("npm run build failed ({0})" -f $LASTEXITCODE)
+        throw ("npm run build 失败（退出码 {0}）。" -f $LASTEXITCODE)
       }
     } finally {
       Pop-Location
@@ -293,7 +302,7 @@ if (-not $SkipBuild) {
 
 foreach ($requiredRuntimeFile in @($HostScript, $coreDist, $adapterDist)) {
   if (-not (Test-Path -LiteralPath $requiredRuntimeFile -PathType Leaf)) {
-    throw ("Missing beautiCode runtime file: {0}" -f $requiredRuntimeFile)
+    throw ("未找到 beautiCode 运行时文件：{0}" -f $requiredRuntimeFile)
   }
 }
 
@@ -328,7 +337,7 @@ if ($DataRoot) {
 $nodeInvocation = [string]::Join(" ", $nodeInvocationParts)
 $bridgeScript = @"
 `$token = [Console]::In.ReadToEnd()
-if ([string]::IsNullOrWhiteSpace(`$token)) { throw "Missing beautiCode control token" }
+if ([string]::IsNullOrWhiteSpace(`$token)) { throw "缺少 beautiCode 控制令牌。" }
 `$env:BEAUTICODE_CONTROL_TOKEN = `$token.Trim()
 & $nodeInvocation
 exit `$LASTEXITCODE
@@ -396,7 +405,7 @@ while ([datetime]::UtcNow -lt $deadline) {
 
 if (-not $ready -or -not $ready.ready) {
   try { if (-not $proc.HasExited) { $proc.Kill() } } catch { }
-  throw "Timed out waiting for session-host ready line."
+  throw "等待 session-host 就绪超时。"
 }
 
 $controlPort = [int]$ready.controlPort
@@ -435,8 +444,32 @@ function Invoke-BcApi {
         $msg = $_.ErrorDetails.Message
       }
     }
-    throw $msg
+    throw (ConvertTo-BcChineseError -Message $msg)
   }
+}
+
+function ConvertTo-BcChineseError {
+  param([AllowNull()][string]$Message)
+  $text = if ($null -eq $Message) { "" } else { [string]$Message }
+  if ($text -match '(?i)failed to fetch|fetch failed|fail fetch|No healthy loopback Codex CDP|CDP is missing or unreachable') {
+    return "未发现注入CDP的Codex进程"
+  }
+  if ($text -match '(?i)No active background|no background|Apply an image or video') {
+    return "当前没有背景，请先应用图片或视频。"
+  }
+  if ($text -match '(?i)Another background apply is already in progress|already in progress|\bbusy\b') {
+    return "已有背景应用正在进行中，请等待当前操作完成。"
+  }
+  if ($text -match '(?i)Session is not started') { return "会话尚未启动。" }
+  if ($text -match '(?i)Host is not connected') { return "尚未连接到 Codex 主机。" }
+  if ($text -match '(?i)Saved theme not found') { return "未找到已保存的主题。" }
+  if ($text -match '(?i)Invalid saved theme id') { return "已保存主题 ID 无效。" }
+  if ($text -match '(?i)No live CDP sessions') { return "未发现活动的 CDP 会话。" }
+  if ($text -match '(?i)Timed out waiting') { return "等待目标就绪超时。" }
+  if ($text -match '(?i)Could not stop ChatGPT/Codex') { return "无法停止 ChatGPT/Codex 进程：$text" }
+  if ($text -match '(?i)Cannot start ChatGPT/Codex') { return "无法启动 ChatGPT/Codex：$text" }
+  if ($text -match '(?i)not found') { return "未找到所需文件或资源：$text" }
+  return $text
 }
 
 function Show-Tip {
@@ -446,6 +479,7 @@ function Show-Tip {
     [ValidateSet("Info", "Warning", "Error", "None")]
     [string]$Icon = "Info"
   )
+  $Text = ConvertTo-BcChineseError -Message $Text
   switch ($Icon) {
     "Warning" { $toolIcon = [System.Windows.Forms.ToolTipIcon]::Warning }
     "Error" { $toolIcon = [System.Windows.Forms.ToolTipIcon]::Error }
@@ -582,7 +616,7 @@ function Start-ChatGptDesktop {
   } catch {
     [void]$errors.Add(("Codex launch: {0}" -f $_.Exception.Message))
   }
-  throw ("Cannot start ChatGPT/Codex. {0}" -f ([string]::Join(" | ", @($errors))))
+  throw ("无法启动 ChatGPT/Codex：{0}" -f ([string]::Join(" | ", @($errors))))
 }
 
 function Stop-ChatGptDesktop {
@@ -637,7 +671,7 @@ function Stop-ChatGptDesktop {
     Start-Sleep -Milliseconds 100
   }
   $remaining = @(Get-Process -Name $names -ErrorAction SilentlyContinue)
-  throw ("Could not stop ChatGPT/Codex processes: {0}" -f (
+  throw ("无法停止 ChatGPT/Codex 进程：{0}" -f (
     [string]::Join(", ", @($remaining | ForEach-Object { $_.Id }))
   ))
 }
@@ -868,7 +902,8 @@ $L = @{
 
 function Show-BcError {
   param([string]$Message)
-  if ($Message -match 'already in progress|Busy|busy') {
+  $Message = ConvertTo-BcChineseError -Message $Message
+  if ($Message -match '已有背景应用正在进行中|already in progress|Busy|busy') {
     Show-Tip -Title $L.AppName -Text $L.BusyTip -Icon Warning
     return
   }
@@ -1057,7 +1092,7 @@ function Invoke-BcToggleFish {
     } else {
       $err = if ($res.error) { [string]$res.error } else { $L.ApplyFail }
       # Common case: no background — show the friendly tip.
-      if ($err -match 'No active background|no background|Apply an image') {
+      if ($err -match '当前没有背景|No active background|no background|Apply an image') {
         $script:fishMode = $false
         if (-not $Silent) {
           Show-Tip -Title $L.AppName -Text $L.FishNeedBg -Icon Warning
@@ -1070,7 +1105,7 @@ function Invoke-BcToggleFish {
     }
   } catch {
     $msg = "{0}" -f $_
-    if ($msg -match 'No active background|no background|Apply an image') {
+    if ($msg -match '当前没有背景|No active background|no background|Apply an image') {
       $script:fishMode = $false
       if (-not $Silent) {
         Show-Tip -Title $L.AppName -Text $L.FishNeedBg -Icon Warning
@@ -1926,11 +1961,17 @@ function Invoke-BcPanelAction {
 }
 
 function Show-BcTrayPanel {
+  param([switch]$EnsureVisible)
   if ($null -eq $script:trayPanel) {
     Show-BcFallbackMenu
     return
   }
   if ($script:trayPanel.Visible) {
+    if ($EnsureVisible) {
+      $script:trayPanel.Activate()
+      $script:trayPanel.BringToFront()
+      return
+    }
     $script:trayPanel.Hide()
     return
   }
@@ -2315,6 +2356,23 @@ try {
   Write-Warning ("Custom tray panel unavailable; native fallback enabled: {0}" -f $_.Exception.Message)
 }
 
+$script:showPanelTimer = New-Object System.Windows.Forms.Timer
+$script:showPanelTimer.Interval = 100
+$null = $script:showPanelTimer.add_Tick({
+    try {
+      if (
+        $null -ne $script:showPanelEvent -and
+        $script:showPanelEvent.WaitOne(0)
+      ) {
+        Write-BcTrayLog "show-panel event received"
+        Show-BcTrayPanel -EnsureVisible
+      }
+    } catch {
+      Write-BcTrayLog ("show-panel event failed: {0}" -f $_.Exception.Message)
+    }
+  })
+$script:showPanelTimer.Start()
+
 Rebuild-BcTrayMenu
 if ($null -ne $script:bcUiColors) { Set-BcFallbackMenuStyle }
 
@@ -2365,6 +2423,15 @@ try {
   try {
     $notify.Visible = $false
     $notify.Dispose()
+  } catch {
+    # ignore
+  }
+  try {
+    if ($null -ne $script:showPanelTimer) {
+      $script:showPanelTimer.Stop()
+      $script:showPanelTimer.Dispose()
+      $script:showPanelTimer = $null
+    }
   } catch {
     # ignore
   }
@@ -2426,5 +2493,9 @@ try {
     }
     try { $script:trayInstanceMutex.Dispose() } catch { }
     $script:trayInstanceMutex = $null
+  }
+  if ($null -ne $script:showPanelEvent) {
+    try { $script:showPanelEvent.Dispose() } catch { }
+    $script:showPanelEvent = $null
   }
 }

--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -620,8 +620,7 @@ function Start-ChatGptDesktop {
 }
 
 function Stop-ChatGptDesktop {
-  $names = @("ChatGPT", "Codex")
-  $targets = @(Get-Process -Name $names -ErrorAction SilentlyContinue)
+  $targets = @(Get-BcCodexMainProcesses)
   if ($targets.Count -eq 0) { return $true }
 
   $answer = [System.Windows.Forms.MessageBox]::Show(
@@ -636,18 +635,8 @@ function Stop-ChatGptDesktop {
     return $false
   }
 
-  # Ask the main windows to close first so the app can flush unsaved state.
-  foreach ($p in $targets) {
-    try {
-      if ($p.MainWindowHandle -ne 0) { [void]$p.CloseMainWindow() }
-    } catch { }
-  }
-  $deadline = [datetime]::UtcNow.AddSeconds(5)
-  while ([datetime]::UtcNow -lt $deadline) {
-    $left = @(Get-Process -Name $names -ErrorAction SilentlyContinue)
-    if ($left.Count -eq 0) { return $true }
-    Start-Sleep -Milliseconds 100
-  }
+  # Shared helper: CloseMainWindow first, then a non-force Stop-Process.
+  if (Stop-BcCodexGracefully -WaitSeconds 5) { return $true }
 
   $answer = [System.Windows.Forms.MessageBox]::Show(
     $L.ForceCloseConfirm,
@@ -660,19 +649,12 @@ function Stop-ChatGptDesktop {
     Show-Tip -Title $L.AppName -Text $L.RestartCancelled -Icon Info
     return $false
   }
-  $left = @(Get-Process -Name $names -ErrorAction SilentlyContinue)
-  foreach ($p in $left) {
-    try { Stop-Process -Id $p.Id -Force -ErrorAction Stop } catch { }
-  }
-  $deadline = [datetime]::UtcNow.AddSeconds(2)
-  while ([datetime]::UtcNow -lt $deadline) {
-    $left = @(Get-Process -Name $names -ErrorAction SilentlyContinue)
-    if ($left.Count -eq 0) { return $true }
-    Start-Sleep -Milliseconds 100
-  }
-  $remaining = @(Get-Process -Name $names -ErrorAction SilentlyContinue)
+
+  if (Stop-BcCodexForcefully -WaitSeconds 3) { return $true }
+
+  $remaining = @(Get-BcCodexMainProcesses)
   throw ("无法停止 ChatGPT/Codex 进程：{0}" -f (
-    [string]::Join(", ", @($remaining | ForEach-Object { $_.Id }))
+    [string]::Join(", ", @($remaining | ForEach-Object { $_.Process.Id }))
   ))
 }
 
@@ -1983,10 +1965,8 @@ function Show-BcTrayPanel {
     $cursor = [System.Windows.Forms.Cursor]::Position
     $screen = [System.Windows.Forms.Screen]::FromPoint($cursor)
     $work = $screen.WorkingArea
-    $x = $cursor.X - $script:trayPanel.Width + 20
-    $y = $cursor.Y - $script:trayPanel.Height - 10
-    $x = [Math]::Max($work.Left + 8, [Math]::Min($x, $work.Right - $script:trayPanel.Width - 8))
-    $y = [Math]::Max($work.Top + 8, [Math]::Min($y, $work.Bottom - $script:trayPanel.Height - 8))
+    $x = [Math]::Max($work.Left + 8, $work.Right - $script:trayPanel.Width - 8)
+    $y = [Math]::Max($work.Top + 8, $work.Bottom - $script:trayPanel.Height - 8)
     $script:trayPanel.Location = New-Object System.Drawing.Point($x, $y)
     $script:trayPanel.Show()
     $script:trayPanel.Activate()

--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -4,7 +4,7 @@
 #define MyAppPublisher "beautiCode"
 
 #ifndef MyAppVersion
-  #define MyAppVersion "0.1.2"
+  #define MyAppVersion "0.1.3"
 #endif
 
 #ifndef StageDir

--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -4,7 +4,7 @@
 #define MyAppPublisher "beautiCode"
 
 #ifndef MyAppVersion
-  #define MyAppVersion "0.1.3"
+  #define MyAppVersion "0.1.4"
 #endif
 
 #ifndef StageDir

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
-{
+﻿{
   "name": "beauticode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beauticode",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beauticode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beauticode",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beauticode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "description": "Local image/video backgrounds for supported coding hosts. Unofficial.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beauticode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "description": "Local image/video backgrounds for supported coding hosts. Unofficial.",

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -72,3 +72,5 @@ export {
   BeautiSession,
   type BeautiSessionOptions,
 } from "./session.js";
+
+export { toChineseErrorMessage } from "@beauticode/core";

--- a/packages/adapter-codex/src/renderer/background-runtime.js
+++ b/packages/adapter-codex/src/renderer/background-runtime.js
@@ -25,6 +25,29 @@
   const VIDEO_INPUT_ID = "beauticode-video-input";
   const gen = Number(generation) || 0;
 
+  const toChineseMediaError = (error) => {
+    const message = String(error?.message || error || "").trim();
+    if (/^(?:failed to fetch|fetch failed|fail fetch)$/i.test(message)) {
+      return "未发现注入CDP的Codex进程";
+    }
+    if (/media fetch failed/i.test(message)) {
+      return "背景媒体加载失败。";
+    }
+    if (/data url fetch failed/i.test(message)) {
+      return "背景数据加载失败。";
+    }
+    if (/missing (?:media )?url|no video source/i.test(message)) {
+      return "背景媒体地址缺失。";
+    }
+    if (/malformed data url/i.test(message)) {
+      return "背景数据地址格式错误。";
+    }
+    if (/stale generation/i.test(message)) {
+      return "背景版本已过期，正在重新加载。";
+    }
+    return message || "背景媒体加载失败。";
+  };
+
   const root = document.documentElement;
   const previous = window.__BEAUTICODE_BG__;
 
@@ -1105,7 +1128,7 @@
     videoReady = false;
     videoError = {
       name: error?.name || null,
-      message: error?.message || null,
+      message: toChineseMediaError(error),
       mediaCode: videoEl?.error?.code ?? null,
       readyState: videoEl?.readyState ?? null,
     };

--- a/packages/core/src/error-message.ts
+++ b/packages/core/src/error-message.ts
@@ -1,0 +1,181 @@
+/**
+ * Convert application errors to concise Chinese text at user-facing
+ * boundaries. Internal error strings remain English so protocol matching and
+ * recovery logic keep their existing semantics.
+ */
+export function toChineseErrorMessage(value: unknown): string {
+  const raw = value instanceof Error ? value.message : String(value ?? "");
+  const message = raw.trim();
+  if (!message) return "未知错误。";
+
+  // Chromium/Node use both spellings for the same missing-CDP symptom.
+  if (/^(?:error:\s*)?(?:failed to fetch|fetch failed|fail fetch)$/i.test(message)) {
+    return "未发现注入CDP的Codex进程";
+  }
+
+  const rules: Array<[RegExp, string | ((match: RegExpExecArray) => string)]> = [
+    [
+      /No healthy loopback Codex CDP endpoint found.*$/i,
+      "未发现健康的本机 Codex CDP 端点，请先打开 Codex Desktop。",
+    ],
+    [/No CDP port configured\. Pass --port or enable auto-discover\.?/i, "未配置 CDP 端口，请传入 --port 或启用自动发现。"],
+    [/CDP is missing or unreachable \(fail closed\)\.?/i, "未发现可用的 CDP 连接。"],
+    [/ECONNREFUSED/i, "无法连接到目标服务（连接被拒绝）。"],
+    [/ECONNRESET/i, "与目标服务的连接已重置。"],
+    [/ETIMEDOUT|connection timed out/i, "操作超时。"],
+    [/aborted/i, "操作已中止。"],
+    [/No candidate page targets on CDP port/i, "CDP 端口上未发现可注入的页面。"],
+    [/No live CDP sessions to apply background/i, "没有可应用背景的活动 CDP 会话。"],
+    [/No live CDP sessions/i, "未发现活动的 CDP 会话。"],
+    [/Timed out waiting for a CDP page target/i, "等待 CDP 页面超时。"],
+    [/CDP target is missing webSocketDebuggerUrl/i, "CDP 目标缺少 WebSocket 调试地址。"],
+    [/CDP webSocketDebuggerUrl is not a valid URL/i, "CDP WebSocket 调试地址无效。"],
+    [/Rejected a CDP WebSocket URL outside the allowed loopback endpoint shape/i, "已拒绝非本机回环地址的 CDP WebSocket。"],
+    [/Rejected an invalid CDP browser identity URL/i, "CDP 浏览器身份地址无效。"],
+    [
+      /CDP HTTP (\d+) for (.+)/i,
+      (match) => `CDP 请求失败（HTTP ${match[1]}）：${match[2]}`,
+    ],
+    [/CDP response exceeded (.+) bytes(?: \(declared (.+)\))?\.?/i, (match) => `CDP 响应超过安全大小限制（${match[1]} 字节）。`],
+    [/CDP response had no readable body for (.+)/i, (match) => `CDP 响应没有可读取的内容：${match[1]}`],
+    [/CDP \/json\/version returned an unexpected shape\.?/i, "CDP 版本信息格式异常。"],
+    [/CDP \/json\/list is not an array/i, "CDP 页面列表格式异常。"],
+    [/CDP \/json\/list exceeded target count safety cap/i, "CDP 页面数量超过安全上限。"],
+    [/CDP browser identity changed from (.+) to (.+)/i, (match) => `CDP 浏览器身份已变化（${match[1] ?? "旧"} → ${match[2] ?? "新"}）。`],
+    [/CDP WebSocket open timed out/i, "CDP WebSocket 连接超时。"],
+    [/CDP WebSocket open failed/i, "CDP WebSocket 连接失败。"],
+    [/CDP socket closed/i, "CDP 套接字已关闭。"],
+    [/CDP session is closed/i, "CDP 会话已关闭。"],
+    [/CDP command timed out:\s*(.*)/i, (match) => `CDP 命令执行超时：${match[1] ?? "未知命令"}`],
+    [/Renderer evaluation failed:\s*(.*)/i, (match) => `渲染器执行失败：${match[1] ?? "未知错误"}`],
+    [/CDP probe only allows loopback hosts\.?/i, "CDP 探测只允许本机回环地址。"],
+    [/CDP port must be an integer 1[–-]65535\.?/i, "CDP 端口必须是 1–65535 之间的整数。"],
+    [/Session already stopped/i, "会话已经停止。"],
+    [/Session is not started/i, "会话尚未启动。"],
+    [/Session already started/i, "会话已经启动。"],
+    [/Host is not connected/i, "尚未连接到 Codex 主机。"],
+    [/CodexHostApplier is closed/i, "Codex 注入器已经关闭。"],
+    [/Another beautiCode injector is running \(pid (\d+)\)\.?/i, (match) => `另一个 beautiCode 注入器正在运行（进程 ${match[1] ?? "未知"}）。`],
+    [/CodexHostApplier port must be 1[–-]65535/i, "Codex 注入器端口必须是 1–65535 之间的整数。"],
+    [/Another (.+) is running \(pid (\d+)\)\.?/i, (match) => `另一个${match[1] ?? "操作"}正在运行（进程 ${match[2] ?? "未知"}）。`],
+    [/Another (.+) may be starting; lock owner is not readable yet\.?/i, (match) => `另一个${match[1] ?? "操作"}可能正在启动，暂时无法读取锁的所有者。`],
+    [/Another background apply is already in progress\.?/i, "已有背景应用正在进行中，请等待当前操作完成。"],
+    [/No active background\. Apply an image or video first\.?/i, "当前没有背景，请先应用图片或视频。"],
+    [/Live verify did not pass \(([^)]+)\):\s*(.*)/i, (match) => `实时校验未通过（${translateVerifyStatus(match[1] ?? "") }）：${translateReadinessReason(match[2] ?? "")}`],
+    [/Failed to inject background into any session:\s*(.*)/i, (match) => `未能向任何会话注入背景：${match[1]}`],
+    [/Could not attach the local MP4 through CDP:\s*(.*)/i, (match) => `无法通过 CDP 附加本地 MP4：${translateMediaDetail(match[1] ?? "")}`],
+    [/Could not toggle fish mode on any session/i, "无法在任何会话中切换摸鱼模式。"],
+    [/Could not set background tone on any session/i, "无法在任何会话中设置背景色调。"],
+    [/Could not toggle mute on any session/i, "无法在任何会话中切换视频声音。"],
+    [/runtime rejected fish mode \(no background\?\)/i, "运行时拒绝摸鱼模式：当前没有背景。"],
+    [/runtime rejected mute toggle/i, "运行时拒绝切换视频声音。"],
+    [/renderer does not support background tone/i, "当前渲染器不支持背景色调。"],
+    [/video decode\/playback failed/i, "视频解码或播放失败。"],
+    [/video node missing/i, "未找到视频节点。"],
+    [/video has no playable local source/i, "视频没有可播放的本地来源。"],
+    [/poster\/image decode failed/i, "海报图片解码失败。"],
+    [/poster\/image missing/i, "未找到海报图片。"],
+    [/background stage missing/i, "未找到背景渲染层。"],
+    [/clear expected but background still active/i, "预期已清除背景，但背景仍处于活动状态。"],
+    [/generation mismatch \(page=(.+), expected=(.+)\)/i, (match) => `背景版本不匹配（页面=${match[1]}，预期=${match[2]}）。`],
+    [/horizontal document overflow detected/i, "检测到页面出现横向溢出。"],
+    [/empty readiness snapshot/i, "未读取到渲染就绪状态。"],
+    [/snapshot missing generation/i, "渲染状态缺少背景版本号。"],
+    [/video expected but renderer reports (.+)/i, (match) => `预期显示视频，但渲染器报告：${match[1] ?? "未知状态"}。`],
+    [/stage pointer-events must be none \(got (.+)\)/i, (match) => `背景层 pointer-events 必须为 none（当前为 ${match[1]}）。`],
+    [/Video background is missing a video basename\.?/i, "视频背景缺少视频文件名。"],
+    [/Video payload requires a detached runtime copy\.?/i, "视频载荷需要独立的运行时副本。"],
+    [/Unsupported media extension(?: for data URL)?:\s*(.*)/i, (match) => `不支持的媒体扩展名：${match[1]}`],
+    [/Could not acquire (.+) lock\.?/i, (match) => `无法获取${match[1]}锁。`],
+    [/Interrupted commit could not recover either active generation\.?/i, "中断的提交无法恢复任何一个活动版本。"],
+    [/Runtime media root must be a real directory\.?/i, "运行时媒体根目录必须是真实目录。"],
+    [/Runtime media session must be a real directory\.?/i, "运行时媒体会话目录必须是真实目录。"],
+    [/Snapshot must be a generated child of the snapshots directory\.?/i, "快照必须位于快照目录生成的子目录中。"],
+    [/Snapshot directory cannot be a link\.?/i, "快照目录不能是链接。"],
+    [/Snapshot manifest is invalid\.?/i, "快照清单无效。"],
+    [/Promoted active manifest is invalid\.?/i, "提升后的活动清单无效。"],
+    [/Theme name must be 1[–-]80 characters\.?/i, "主题名称长度必须为 1–80 个字符。"],
+    [/Theme name contains illegal characters\.?/i, "主题名称包含非法字符。"],
+    [/No active background to save\.?/i, "当前没有可保存的背景。"],
+    [/Saved theme limit reached \((\d+)\)\. Delete one before saving\.?/i, (match) => `已达到保存主题数量上限（${match[1]}），请先删除一个主题。`],
+    [/Saved theme storage limit exceeded \((\d+) bytes\)\. Delete a theme before saving\.?/i, (match) => `已超过保存主题的存储上限（${match[1]} 字节），请先删除一个主题。`],
+    [/Invalid saved theme id\.?/i, "已保存主题 ID 无效。"],
+    [/Saved theme not found\.?/i, "未找到已保存的主题。"],
+    [/Invalid video position\.?/i, "视频位置无效。"],
+    [/Theme meta unreadable\.?/i, "主题元数据无法读取。"],
+    [/Theme meta invalid\.?/i, "主题元数据无效。"],
+    [/Not a video theme\.?/i, "该主题不是视频主题。"],
+    [/Saved theme manifest is invalid\.?/i, "已保存主题清单无效。"],
+    [/Saved video theme has no video file\.?/i, "已保存的视频主题缺少视频文件。"],
+    [/Saved theme path escaped saved root\.?/i, "已保存主题路径越过了保存目录。"],
+    [/Saved theme directory cannot be a link\.?/i, "已保存主题目录不能是链接。"],
+    [/Saved theme real path escaped saved root\.?/i, "已保存主题真实路径越过了保存目录。"],
+    [/Staging transaction escaped staging root\.?/i, "暂存事务越过了暂存目录。"],
+    [/Invalid media commit payload\.?/i, "媒体提交载荷无效。"],
+    [/Media file ended while revalidating/i, "媒体文件在重新校验时提前结束。"],
+    [/Media hub is closed/i, "媒体服务已关闭。"],
+    [/Local media server did not expose a TCP port\.?/i, "本地媒体服务未提供 TCP 端口。"],
+    [/Media hub closed while listener was starting\.?/i, "媒体服务在监听器启动时已关闭。"],
+    [/Media path became a symbolic link/i, "媒体路径变成了符号链接。"],
+    [/Media file changed or exceeded the safety limit/i, "媒体文件已变化或超过安全限制。"],
+    [/Media file content changed after staging/i, "媒体文件在暂存后发生了内容变化。"],
+    [/Media file too large to embed as data URL \((\d+) > (\d+)\)\.?/i, (match) => `媒体文件过大，无法嵌入数据地址（${match[1]}/${match[2]} 字节）。`],
+    [/beautiCode data root must be a real directory\.?/i, "beautiCode 数据根目录必须是真实目录。"],
+    [/beautiCode data-root ownership marker is invalid\.?/i, "beautiCode 数据目录所有权标记无效。"],
+    [/Media file not found:\s*(.*)/i, (match) => `未找到媒体文件：${match[1]}`],
+    [/Media path must be a regular file\.?/i, "媒体路径必须指向普通文件。"],
+    [/Image must use one of:\s*(.*)/i, (match) => `图片必须使用以下扩展名之一：${match[1]}`],
+    [/Image must be a non-empty file no larger than (\d+) bytes\.?/i, (match) => `图片必须是非空文件，且不超过 ${match[1]} 字节。`],
+    [/Image content does not match a supported JPEG\/PNG\/WEBP\/AVIF signature\.?/i, "图片内容与支持的 JPEG/PNG/WEBP/AVIF 格式不匹配。"],
+    [/Video backgrounds must use an MP4 file\.?/i, "视频背景必须使用 MP4 文件。"],
+    [/Video background must be a non-empty MP4 no larger than (\d+) bytes\.?/i, (match) => `视频背景必须是非空 MP4 文件，且不超过 ${match[1]} 字节。`],
+    [/Video background is not a valid MP4 container\.?/i, "视频背景不是有效的 MP4 容器。"],
+    [/must be a basename string\.?/i, "必须是文件名字符串。"],
+    [/must be a basename only\.?/i, "只能是文件名，不能包含路径。"],
+    [/contains illegal path characters\.?/i, "包含非法路径字符。"],
+    [/contains characters invalid in Windows basenames\.?/i, "包含 Windows 文件名不允许的字符。"],
+    [/uses a reserved device name\.?/i, "使用了 Windows 保留设备名。"],
+    [/contains control characters\.?/i, "包含控制字符。"],
+    [/missing data url/i, "缺少数据地址。"],
+    [/data url fetch failed:\s*(\d+)/i, (match) => `数据地址加载失败（HTTP ${match[1]}）。`],
+    [/malformed data url/i, "数据地址格式错误。"],
+    [/missing media url/i, "缺少媒体地址。"],
+    [/media fetch failed:\s*(\d+)/i, (match) => `媒体加载失败（HTTP ${match[1]}）。`],
+    [/no video source/i, "没有视频来源。"],
+    [/Renderer did not create the video file input/i, "渲染器未创建视频文件输入框。"],
+    [/DOM\.getDocument returned no root nodeId/i, "DOM 文档没有返回根节点 ID。"],
+    [/Video file input is not attached to the renderer DOM/i, "视频文件输入框未附加到渲染器 DOM。"],
+    [/stale generation/i, "背景版本已过期，正在重新加载。"],
+    [/request body too large/i, "请求内容过大。"],
+    [/request body must be a JSON object/i, "请求内容必须是 JSON 对象。"],
+    [/unauthorized/i, "未授权的请求。"],
+    [/shutting down/i, "服务正在关闭。"],
+    [/not found/i, "未找到请求的资源。"],
+    [/Unknown flag:\s*(.*)/i, (match) => `未知参数：${match[1] ?? ""}`],
+    [/Refusing to adopt a non-empty directory without beautiCode data\. Choose an empty --data-root\.?/i, "拒绝接管不含 beautiCode 数据的非空目录，请选择空的 --data-root。"],
+  ];
+
+  for (const [pattern, replacement] of rules) {
+    const match = pattern.exec(message);
+    if (!match) continue;
+    return typeof replacement === "function"
+      ? replacement(match)
+      : message.replace(pattern, replacement);
+  }
+
+  return message;
+}
+
+function translateReadinessReason(reason: string): string {
+  return toChineseErrorMessage(reason);
+}
+
+function translateVerifyStatus(status: string): string {
+  if (/^fail$/i.test(status)) return "失败";
+  if (/^inconclusive$/i.test(status)) return "无法确定";
+  return status;
+}
+
+function translateMediaDetail(detail: string): string {
+  return toChineseErrorMessage(detail);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,5 +9,6 @@ export {
   type DataPaths,
 } from "./paths.js";
 export * from "./file-lock.js";
+export * from "./error-message.js";
 export * from "./background-store.js";
 export * from "./apply-transaction.js";

--- a/packages/core/test/error-message.test.js
+++ b/packages/core/test/error-message.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toChineseErrorMessage } from "../dist/error-message.js";
+
+test("user-facing CDP errors are localized", () => {
+  assert.equal(
+    toChineseErrorMessage("Failed to fetch"),
+    "未发现注入CDP的Codex进程",
+  );
+  assert.equal(
+    toChineseErrorMessage(
+      "No healthy loopback Codex CDP endpoint found. Open Codex Desktop, then use tray 应用或重新应用.",
+    ),
+    "未发现健康的本机 Codex CDP 端点，请先打开 Codex Desktop。",
+  );
+  assert.equal(
+    toChineseErrorMessage("Live verify did not pass (fail): video node missing"),
+    "实时校验未通过（失败）：未找到视频节点。",
+  );
+});

--- a/scripts/beauticode.mjs
+++ b/scripts/beauticode.mjs
@@ -12,7 +12,7 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 if (Number(process.versions.node.split(".", 1)[0]) < 22) {
-  console.error("beautiCode requires Node.js 22 or newer");
+  console.error("beautiCode 需要 Node.js 22 或更高版本。");
   process.exit(1);
 }
 
@@ -30,6 +30,7 @@ const {
   BackgroundStore,
   MediaServerController,
   defaultDataRoot,
+  toChineseErrorMessage,
 } = await import(coreEntry);
 
 function finish(code) {
@@ -88,28 +89,28 @@ function parseArgs(argv) {
     if (a === "--port") {
       const v = Number(argv[++i]);
       if (!Number.isInteger(v) || v < 1 || v > 65535) {
-        throw new Error("--port must be an integer 1–65535");
+        throw new Error("--port 必须是 1–65535 之间的整数。");
       }
       flags.port = v;
       continue;
     }
     if (a === "--data-root") {
       const value = argv[++i];
-      if (!value) throw new Error("--data-root requires a path");
+      if (!value) throw new Error("--data-root 需要一个路径。");
       flags.dataRoot = path.resolve(value);
       continue;
     }
     if (a === "--verify-ms") {
       const v = Number(argv[++i]);
       if (!Number.isFinite(v) || v < 0 || v > 300_000) {
-        throw new Error("--verify-ms must be between 0 and 300000");
+        throw new Error("--verify-ms 必须在 0 到 300000 之间。");
       }
       flags.verifyMs = v;
       continue;
     }
     if (a === "--url-prefix") {
       const value = argv[++i];
-      if (!value) throw new Error("--url-prefix requires a value");
+      if (!value) throw new Error("--url-prefix 需要一个值。");
       flags.urlPrefix = value;
       continue;
     }
@@ -122,7 +123,7 @@ function parseArgs(argv) {
       continue;
     }
     if (a.startsWith("-")) {
-      throw new Error(`Unknown flag: ${a}`);
+      throw new Error(`未知参数：${a}`);
     }
     positionals.push(a);
   }
@@ -130,37 +131,43 @@ function parseArgs(argv) {
 }
 
 function friendlyError(err) {
-  const msg = err instanceof Error ? err.message : String(err);
+  const raw = err instanceof Error ? err.message : String(err);
+  const msg = toChineseErrorMessage(raw);
   if (
     /fetch failed|ECONNREFUSED|aborted|CDP HTTP|Timed out waiting for a CDP|No healthy loopback/i.test(
-      msg,
+      raw,
     )
   ) {
     return [
       msg,
       "",
-      "CDP is missing or unreachable (fail closed).",
-      "Run: npm run bc -- discover",
-      "Or:  npm run bc -- how-to-cdp",
+      "未发现可用的 CDP 连接。",
+      "请运行：npm run bc -- discover",
+      "或运行：npm run bc -- how-to-cdp",
     ].join("\n");
   }
-  if (/Another beautiCode injector is running/i.test(msg)) {
+  if (/Another beautiCode injector is running/i.test(raw)) {
     return [
       msg,
       "",
-      "Only one injector may own a host at a time.",
-      "Stop the other process and retry. Dead-pid locks are reclaimed automatically.",
+      "同一时间只能有一个 beautiCode 注入器占用主机。",
+      "请停止另一个进程后重试；失效进程锁会自动回收。",
     ].join("\n");
   }
-  if (/identity changed|CdpIdentityMismatch/i.test(msg)) {
+  if (/identity changed|CdpIdentityMismatch/i.test(raw)) {
     return [
       msg,
       "",
-      "The Chromium browser identity behind the CDP port changed (host relaunch).",
-      "Re-run probe/apply; watch/tray reconnects automatically.",
+      "CDP 端口背后的 Chromium 浏览器身份已变化，主机可能刚刚重启。",
+      "请重新运行 probe/apply；watch/托盘会自动重连。",
     ].join("\n");
   }
   return msg;
+}
+
+function localizeResult(result) {
+  if (!result || typeof result.error !== "string") return result;
+  return { ...result, error: toChineseErrorMessage(result.error) };
 }
 
 async function resolvePort(flags, adapter) {
@@ -169,7 +176,7 @@ async function resolvePort(flags, adapter) {
   const best = await adapter.findBestCdpPort({ requirePages: true });
   if (!best) {
     throw new Error(
-      "No healthy loopback Codex CDP endpoint found (discover failed closed).",
+      "未发现健康的本机 Codex CDP 端点，请先打开 Codex Desktop。",
     );
   }
   console.error(
@@ -260,7 +267,7 @@ async function main() {
       port = await resolvePort(flags, adapter);
     }
     if (port == null) {
-      console.error("probe requires --port <cdpPort> or --discover");
+      console.error("probe 需要 --port <cdpPort> 或 --discover。");
       finish(1);
       return;
     }
@@ -294,7 +301,7 @@ async function main() {
     let port = flags.port;
     if (port == null) port = await resolvePort({ ...flags, discover: flags.discover || flags.port == null }, adapter);
     if (port == null) {
-      console.error("watch requires --port <cdpPort> or --discover");
+      console.error("watch 需要 --port <cdpPort> 或 --discover。");
       finish(1);
       return;
     }
@@ -315,7 +322,7 @@ async function main() {
         }
       },
       onError: (err) => {
-        console.error(`[watch] ${err.message}`);
+        console.error(`[watch] ${toChineseErrorMessage(err)}`);
       },
     });
     finish(0);
@@ -358,7 +365,7 @@ async function main() {
       input = { type: "video", videoPath: aPath };
     } else {
       console.error(
-        "apply-video expects <video.mp4> [poster] (or legacy <poster> <video.mp4>)",
+        "apply-video 需要 <video.mp4> [poster]（或旧格式 <poster> <video.mp4>）。",
       );
       finish(1);
       return;
@@ -385,7 +392,7 @@ async function main() {
       requireAppProtocol: !flags.allowHttp,
       ...(flags.urlPrefix !== undefined ? { urlPrefix: flags.urlPrefix } : {}),
     });
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(localizeResult(result), null, 2));
     finish(result.ok ? 0 : 2);
     return;
   }
@@ -395,7 +402,7 @@ async function main() {
   const tx = new ApplyTransaction({ store, media, offline: true });
   try {
     const result = await tx.run(input);
-    console.log(JSON.stringify(result, null, 2));
+    console.log(JSON.stringify(localizeResult(result), null, 2));
     if (media.active) {
       console.log("mediaServer:", media.active.url);
       console.log(

--- a/scripts/codex-launch.ps1
+++ b/scripts/codex-launch.ps1
@@ -18,6 +18,66 @@ function Get-BcCodexMainProcesses {
   }
 }
 
+function Wait-BcCodexMainProcessesExit([int]$WaitSeconds = 8) {
+  $deadline = [datetime]::UtcNow.AddSeconds([Math]::Max(1, $WaitSeconds))
+  do {
+    if (@(Get-BcCodexMainProcesses).Count -eq 0) { return $true }
+    Start-Sleep -Milliseconds 250
+  } while ([datetime]::UtcNow -lt $deadline)
+  return (@(Get-BcCodexMainProcesses).Count -eq 0)
+}
+
+# Ask main windows to close first. Electron/Codex often ignores a single
+# CloseMainWindow, so also fall back to Stop-Process (non-force) which still
+# prefers a graceful close on Windows GUI apps.
+function Stop-BcCodexGracefully([int]$WaitSeconds = 8) {
+  $targets = @(Get-BcCodexMainProcesses)
+  if ($targets.Count -eq 0) { return $true }
+
+  foreach ($target in $targets) {
+    try {
+      $target.Process.Refresh()
+      if ($target.Process.MainWindowHandle -ne [IntPtr]::Zero) {
+        [void]$target.Process.CloseMainWindow()
+      }
+    } catch { }
+  }
+
+  if (Wait-BcCodexMainProcessesExit -WaitSeconds ([Math]::Min(3, [Math]::Max(1, $WaitSeconds)))) {
+    return $true
+  }
+
+  foreach ($target in @(Get-BcCodexMainProcesses)) {
+    try {
+      Stop-Process -Id $target.Process.Id -ErrorAction Stop
+    } catch { }
+  }
+
+  return (Wait-BcCodexMainProcessesExit -WaitSeconds $WaitSeconds)
+}
+
+# Last resort after the user already agreed to restart / force-close.
+# Kills main ChatGPT/Codex.exe only (not helper processes under \resources\).
+function Stop-BcCodexForcefully([int]$WaitSeconds = 3) {
+  foreach ($target in @(Get-BcCodexMainProcesses)) {
+    try {
+      Stop-Process -Id $target.Process.Id -Force -ErrorAction Stop
+    } catch { }
+  }
+  if (Wait-BcCodexMainProcessesExit -WaitSeconds $WaitSeconds) {
+    return $true
+  }
+
+  # AppX / stubborn Electron trees sometimes leave the main image alive until
+  # the process tree is torn down. taskkill /T is Windows-only and scoped by PID.
+  foreach ($target in @(Get-BcCodexMainProcesses)) {
+    try {
+      $null = & taskkill.exe /PID $target.Process.Id /T /F 2>$null
+    } catch { }
+  }
+  return (Wait-BcCodexMainProcessesExit -WaitSeconds $WaitSeconds)
+}
+
 function Get-BcCodexPackageLocations {
   $packages = @()
   try {

--- a/scripts/codex-launch.ps1
+++ b/scripts/codex-launch.ps1
@@ -1,4 +1,4 @@
-# Shared Windows Codex discovery and loopback launch helpers.
+﻿# Shared Windows Codex discovery and loopback launch helpers.
 # This file is dot-sourced by both the one-click launcher and the tray process.
 
 $script:BeautiCodeKnownCodexAppUserModelId = "OpenAI.Codex_2p2nqsd0c76g0!App"
@@ -170,5 +170,5 @@ function Start-BcCodexWithCdp([int]$CdpPort = 9335) {
     }
   }
 
-  throw "Cannot find an installed Codex/ChatGPT Desktop application. Install Codex Desktop first."
+  throw "找不到已安装的 Codex/ChatGPT Desktop 应用，请先安装 Codex Desktop。"
 }

--- a/scripts/start-beauticode-engine.ps1
+++ b/scripts/start-beauticode-engine.ps1
@@ -218,25 +218,6 @@ function Confirm-BcCodexAction {
   }
 }
 
-function Stop-BcCodexGracefully([int]$WaitSeconds = 8) {
-  $targets = @(Get-BcCodexMainProcesses)
-  foreach ($target in $targets) {
-    try {
-      if ($target.Process.MainWindowHandle -ne [IntPtr]::Zero) {
-        [void]$target.Process.CloseMainWindow()
-      }
-    } catch {
-      Write-BcLog ("无法请求 Codex 平稳关闭：{0}" -f $_.Exception.Message)
-    }
-  }
-  $deadline = [datetime]::UtcNow.AddSeconds([Math]::Max(1, $WaitSeconds))
-  do {
-    if (@(Get-BcCodexMainProcesses).Count -eq 0) { return $true }
-    Start-Sleep -Milliseconds 250
-  } while ([datetime]::UtcNow -lt $deadline)
-  return (@(Get-BcCodexMainProcesses).Count -eq 0)
-}
-
 function Start-CodexWithCdpFast([int]$CdpPort) {
   if ($CdpPort -le 0 -or $CdpPort -gt 65535) {
     $CdpPort = Get-BcLoopbackCdpPort
@@ -377,8 +358,30 @@ try {
       # session-host watcher can import the active background immediately.
       $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex 已在运行，但未发现可用的 CDP 端点。`n`n若要让 beautiCode 连接此窗口并恢复当前背景，必须安全重启 ChatGPT/Codex。未保存的内容可能会丢失。现在重启吗？"
       if ($accepted) {
-        Write-BcLog "no CDP and Codex already running - user accepted graceful restart"
-        if (Stop-BcCodexGracefully) {
+        Write-BcLog "no CDP and Codex already running - user accepted restart"
+        $stopped = $false
+        try {
+          $stopped = Stop-BcCodexGracefully
+        } catch {
+          Write-BcLog ("Codex graceful stop failed: {0}" -f $_.Exception.Message)
+          $stopped = $false
+        }
+        if (-not $stopped) {
+          Write-BcLog "Codex did not exit gracefully - asking to force close"
+          $forceAccepted = Confirm-BcCodexAction -Text "ChatGPT/Codex 未能在超时时间内安全退出。`n`n是否强制结束剩余进程并重新打开？未保存的内容可能会丢失。"
+          if ($forceAccepted) {
+            Write-BcLog "user accepted force close"
+            try {
+              $stopped = Stop-BcCodexForcefully
+            } catch {
+              Write-BcLog ("Codex force stop failed: {0}" -f $_.Exception.Message)
+              $stopped = $false
+            }
+          } else {
+            Write-BcLog "user declined force close"
+          }
+        }
+        if ($stopped) {
           if (Start-CodexWithCdpFast -CdpPort $launchPort) {
             $readyPort = Wait-BcCdpReady -Preferred $launchPort -WaitSeconds 15
             if ($readyPort -gt 0) {
@@ -393,8 +396,8 @@ try {
             Show-BcMessage -Icon "Error" -Text "无法通过本机 CDP 端点重新打开 ChatGPT/Codex。请查看 beautiCode 启动日志后重试。"
           }
         } else {
-          Write-BcLog "Codex graceful restart stopped: process did not exit"
-          Show-BcMessage -Icon "Warning" -Text "Codex 未能在超时时间内安全退出。beautiCode 未强制关闭它。请使用托盘中的“应用”或“重新应用”重试。"
+          Write-BcLog "Codex restart aborted: process still running"
+          Show-BcMessage -Icon "Warning" -Text "Codex 仍在运行，重启已取消。请手动关闭 ChatGPT/Codex 后，使用托盘中的“应用或重新应用”重试。"
         }
       } else {
         Write-BcLog "no CDP and Codex already running - user declined restart"

--- a/scripts/start-beauticode-engine.ps1
+++ b/scripts/start-beauticode-engine.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
   One-click launcher for the beautiCode engine (system tray).
@@ -18,7 +18,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 if ($Port -lt 0 -or $Port -gt 65535) {
-  throw "Port must be 0 (auto) or an integer from 1 to 65535."
+  throw "端口必须为 0（自动）或 1 到 65535 之间的整数。"
 }
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $TrayScript = Join-Path $RepoRoot "apps\tray\start-tray.ps1"
@@ -31,9 +31,13 @@ $LogRoot = if ($env:LOCALAPPDATA) {
 }
 $LogPath = Join-Path $LogRoot "engine-launcher.log"
 $TrayMutexName = "Local\beautiCode.Engine.Tray.v1"
+$TrayPanelEventName = "Local\beautiCode.Engine.ShowPanel.v1"
+$LauncherMutexName = "Local\beautiCode.Engine.Launcher.v1"
+$script:launcherMutex = $null
+$script:launcherMutexOwned = $false
 
 if (-not (Test-Path -LiteralPath $CodexLaunchScript -PathType Leaf)) {
-  throw "Missing Codex launch helper: $CodexLaunchScript"
+  throw "缺少 Codex 启动脚本：$CodexLaunchScript"
 }
 . $CodexLaunchScript
 
@@ -108,6 +112,43 @@ function Find-BcCdpPortFast([int]$Preferred = 9335) {
   return 0
 }
 
+function Wait-BcCdpReady {
+  param(
+    [int]$Preferred = 0,
+    [int]$WaitSeconds = 15
+  )
+  $deadline = [datetime]::UtcNow.AddSeconds([Math]::Max(1, $WaitSeconds))
+  do {
+    $hit = Find-BcCdpPortFast -Preferred $Preferred
+    if ($hit -gt 0) { return [int]$hit }
+    Start-Sleep -Milliseconds 250
+  } while ([datetime]::UtcNow -lt $deadline)
+  return 0
+}
+
+function Request-BcTrayPanel([int]$WaitMilliseconds = 0) {
+  $deadline = [datetime]::UtcNow.AddMilliseconds([Math]::Max(0, $WaitMilliseconds))
+  do {
+    $showEvent = $null
+    try {
+      $showEvent = [System.Threading.EventWaitHandle]::OpenExisting($TrayPanelEventName)
+      [void]$showEvent.Set()
+      Write-BcLog "tray panel requested"
+      return $true
+    } catch [System.Threading.WaitHandleCannotBeOpenedException] {
+      # The tray creates this event immediately after taking its instance mutex.
+    } finally {
+      if ($null -ne $showEvent) {
+        try { $showEvent.Dispose() } catch {}
+      }
+    }
+    if ([datetime]::UtcNow -ge $deadline) { break }
+    Start-Sleep -Milliseconds 100
+  } while ($true)
+  Write-BcLog "tray panel request timed out"
+  return $false
+}
+
 function Test-BcTrayRunningFast {
   $mutex = $null
   try {
@@ -147,9 +188,19 @@ function Get-CodexMainExeFast {
 
 function Confirm-BcCodexAction {
   param([string]$Text)
+  $owner = $null
   try {
     Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
+    $owner = New-Object System.Windows.Forms.Form
+    $owner.ShowInTaskbar = $false
+    $owner.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
+    $owner.Size = New-Object System.Drawing.Size(1, 1)
+    $owner.Opacity = 0
+    $owner.TopMost = $true
+    $owner.Show()
+    $owner.Activate()
     $result = [System.Windows.Forms.MessageBox]::Show(
+      $owner,
       $Text,
       "beautiCode",
       [System.Windows.Forms.MessageBoxButtons]::YesNo,
@@ -159,6 +210,11 @@ function Confirm-BcCodexAction {
     return $result -eq [System.Windows.Forms.DialogResult]::Yes
   } catch {
     return $false
+  } finally {
+    if ($null -ne $owner) {
+      try { $owner.Close() } catch {}
+      try { $owner.Dispose() } catch {}
+    }
   }
 }
 
@@ -170,7 +226,7 @@ function Stop-BcCodexGracefully([int]$WaitSeconds = 8) {
         [void]$target.Process.CloseMainWindow()
       }
     } catch {
-      Write-BcLog ("could not request graceful Codex close: {0}" -f $_.Exception.Message)
+      Write-BcLog ("无法请求 Codex 平稳关闭：{0}" -f $_.Exception.Message)
     }
   }
   $deadline = [datetime]::UtcNow.AddSeconds([Math]::Max(1, $WaitSeconds))
@@ -194,7 +250,7 @@ function Start-CodexWithCdpFast([int]$CdpPort) {
     }
     return $true
   } catch {
-    Write-BcLog ("Codex launch failed: {0}" -f $_.Exception.Message)
+    Write-BcLog ("Codex 启动失败：{0}" -f $_.Exception.Message)
     return $false
   }
 }
@@ -238,8 +294,23 @@ try {
   $sw = [System.Diagnostics.Stopwatch]::StartNew()
   Write-BcLog ("launcher start Port={0} ForceRestart={1}" -f $Port, [bool]$ForceRestart)
 
+  $launcherCreated = $false
+  $script:launcherMutex = [System.Threading.Mutex]::new(
+    $true,
+    $LauncherMutexName,
+    [ref]$launcherCreated
+  )
+  if (-not $launcherCreated) {
+    Write-BcLog "launcher already active mutex=True"
+    if (-not $NoLaunchCodex) {
+      [void](Request-BcTrayPanel -WaitMilliseconds 5000)
+    }
+    exit 0
+  }
+  $script:launcherMutexOwned = $true
+
   if (-not (Test-Path -LiteralPath $TrayScript)) {
-    throw "Missing tray script: $TrayScript"
+    throw "缺少托盘脚本：$TrayScript"
   }
 
   $trayAlreadyRunning = $false
@@ -268,7 +339,7 @@ try {
     $cdpPort
   } elseif ($Port -gt 0) {
     $Port
-  } elseif ($codexExecutable -and -not $codexAlreadyRunning) {
+  } elseif ($codexExecutable) {
     Get-BcLoopbackCdpPort
   } else {
     0
@@ -293,6 +364,9 @@ try {
     Start-BcTray -CdpPort $trayPort
     Write-BcLog ("tray spawned in {0}ms" -f $sw.ElapsedMilliseconds)
   }
+  if (-not $NoLaunchCodex) {
+    [void](Request-BcTrayPanel -WaitMilliseconds 5000)
+  }
 
   # 3) If no CDP, kick Codex launch after the tray process is already running.
   #    The session-host watch loop attaches when CDP appears.
@@ -301,26 +375,46 @@ try {
       # A normal Codex launch may not expose CDP. Never kill it silently:
       # ask once, close gracefully, then relaunch with loopback CDP so the
       # session-host watcher can import the active background immediately.
-      $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex is already running without a reachable CDP endpoint.`n`nTo let beautiCode match this window and restore the active background, ChatGPT/Codex must restart safely. Unsaved content may be lost. Restart now?"
+      $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex 已在运行，但未发现可用的 CDP 端点。`n`n若要让 beautiCode 连接此窗口并恢复当前背景，必须安全重启 ChatGPT/Codex。未保存的内容可能会丢失。现在重启吗？"
       if ($accepted) {
         Write-BcLog "no CDP and Codex already running - user accepted graceful restart"
         if (Stop-BcCodexGracefully) {
-          if (-not (Start-CodexWithCdpFast -CdpPort $launchPort)) {
-            Show-BcMessage -Icon "Error" -Text "ChatGPT/Codex could not be reopened with a local CDP endpoint. Check the beautiCode launcher log and try again."
+          if (Start-CodexWithCdpFast -CdpPort $launchPort) {
+            $readyPort = Wait-BcCdpReady -Preferred $launchPort -WaitSeconds 15
+            if ($readyPort -gt 0) {
+              $cdpPort = $readyPort
+              Write-BcLog ("Codex CDP ready port={0}" -f $readyPort)
+              [void](Request-BcTrayPanel)
+            } else {
+              Write-BcLog ("Codex CDP readiness timed out preferredPort={0}" -f $launchPort)
+              Show-BcMessage -Icon "Warning" -Text "ChatGPT/Codex 已重新打开，但 CDP 尚未就绪。beautiCode 会继续在后台连接；若稍后仍未恢复，请从托盘重试。"
+            }
+          } else {
+            Show-BcMessage -Icon "Error" -Text "无法通过本机 CDP 端点重新打开 ChatGPT/Codex。请查看 beautiCode 启动日志后重试。"
           }
         } else {
           Write-BcLog "Codex graceful restart stopped: process did not exit"
-          Show-BcMessage -Icon "Warning" -Text "Codex did not exit safely within the timeout. beautiCode did not force-close it. Use the tray action Apply or reapply to try again."
+          Show-BcMessage -Icon "Warning" -Text "Codex 未能在超时时间内安全退出。beautiCode 未强制关闭它。请使用托盘中的“应用”或“重新应用”重试。"
         }
       } else {
         Write-BcLog "no CDP and Codex already running - user declined restart"
       }
     } else {
-      $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex is not running.`n`nOpen it with a local CDP endpoint so beautiCode can match the window and restore the active background?"
+      $accepted = Confirm-BcCodexAction -Text "ChatGPT/Codex 当前未运行。`n`n是否通过本机 CDP 端点打开它，以便 beautiCode 连接窗口并恢复当前背景？"
       if ($accepted) {
         Write-BcLog "no CDP and Codex not running - user accepted launch"
-        if (-not (Start-CodexWithCdpFast -CdpPort $launchPort)) {
-          Show-BcMessage -Icon "Error" -Text "ChatGPT/Codex could not be opened with a local CDP endpoint. Check the beautiCode launcher log and try again."
+        if (Start-CodexWithCdpFast -CdpPort $launchPort) {
+          $readyPort = Wait-BcCdpReady -Preferred $launchPort -WaitSeconds 15
+          if ($readyPort -gt 0) {
+            $cdpPort = $readyPort
+            Write-BcLog ("Codex CDP ready port={0}" -f $readyPort)
+            [void](Request-BcTrayPanel)
+          } else {
+            Write-BcLog ("Codex CDP readiness timed out preferredPort={0}" -f $launchPort)
+            Show-BcMessage -Icon "Warning" -Text "ChatGPT/Codex 已打开，但 CDP 尚未就绪。beautiCode 会继续在后台连接；若稍后仍未恢复，请从托盘重试。"
+          }
+        } else {
+          Show-BcMessage -Icon "Error" -Text "无法通过本机 CDP 端点打开 ChatGPT/Codex。请查看 beautiCode 启动日志后重试。"
         }
       } else {
         Write-BcLog "no CDP and Codex not running - user declined launch"
@@ -333,7 +427,17 @@ try {
   exit 0
 }
 catch {
-  Write-BcLog ("launcher failed: {0}" -f $_.Exception.Message)
-  Show-BcMessage -Icon "Error" -Text ("beautiCode engine failed to start:`n{0}`n`nLog: {1}" -f $_.Exception.Message, $LogPath)
+  Write-BcLog ("启动器失败：{0}" -f $_.Exception.Message)
+  Show-BcMessage -Icon "Error" -Text ("beautiCode 引擎启动失败：`n{0}`n`n日志：{1}" -f $_.Exception.Message, $LogPath)
   exit 1
+}
+finally {
+  if ($null -ne $script:launcherMutex) {
+    if ($script:launcherMutexOwned) {
+      try { $script:launcherMutex.ReleaseMutex() } catch {}
+      $script:launcherMutexOwned = $false
+    }
+    try { $script:launcherMutex.Dispose() } catch {}
+    $script:launcherMutex = $null
+  }
 }


### PR DESCRIPTION
## Summary
- Land the already-published v0.1.3 and v0.1.4 launcher/reliability work onto current `main`
- One-click startup waits for tray + Codex CDP readiness
- Force-close restart fallback for stuck Codex sessions
- Chinese user-facing engine/tray/session errors

## Why
These commits were released as GitHub assets but never merged after PR #3. This PR rebases them onto current `main` so later DSH work can stack cleanly.

## Test plan
- [x] Cherry-picked cleanly onto `origin/main`
- [ ] CI green
- [ ] Confirm README still points at existing public v0.1.4 asset