### PR TITLE
add multi-host session contract and Codex host descriptor

### DIFF
--- a/packages/adapter-codex/src/host-descriptor.ts
+++ b/packages/adapter-codex/src/host-descriptor.ts
@@ -1,0 +1,16 @@
+import type { HostDescriptor } from "@beauticode/core";
+
+export const CODEX_HOST_DESCRIPTOR: HostDescriptor = Object.freeze({
+  kind: "codex",
+  displayName: "Codex Desktop",
+  capabilities: Object.freeze({
+    image: true,
+    clear: true,
+    reapply: true,
+    savedThemes: true,
+    video: true,
+    fish: true,
+    muted: true,
+    tone: true,
+  }),
+});

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -73,4 +73,6 @@ export {
   type BeautiSessionOptions,
 } from "./session.js";
 
+export { CODEX_HOST_DESCRIPTOR } from "./host-descriptor.js";
+
 export { toChineseErrorMessage } from "@beauticode/core";

--- a/packages/adapter-codex/src/session.ts
+++ b/packages/adapter-codex/src/session.ts
@@ -7,8 +7,9 @@ import {
   buildHostApplyPayload,
   type ApplyInput,
   type ApplyResult,
-  type BackgroundManifest,
   type BackgroundTone,
+  type HostSession,
+  type HostSessionStatus,
   type SavedThemeInfo,
 } from "@beauticode/core";
 import { CodexHostApplier } from "./host-applier.js";
@@ -17,6 +18,7 @@ import { probeCdp } from "./discovery.js";
 import { findBestCdpPort } from "./host-discover.js";
 import { acquireInjectorLock } from "./injector-lock.js";
 import { loadRendererSource } from "./payload.js";
+import { CODEX_HOST_DESCRIPTOR } from "./host-descriptor.js";
 
 export interface BeautiSessionOptions {
   /** Fixed CDP port. If omitted, discover() is used on start. */
@@ -44,7 +46,8 @@ export interface BeautiSessionOptions {
  * Video applies use CDP file input → blob inside the renderer. The Codex path
  * keeps its HTTP media controller disabled because app:// CSP blocks loopback.
  */
-export class BeautiSession {
+export class BeautiSession implements HostSession {
+  readonly descriptor = CODEX_HOST_DESCRIPTOR;
   readonly dataRoot: string;
   readonly verifyDeadlineMs: number;
   readonly requireAppProtocol: boolean;
@@ -311,18 +314,11 @@ export class BeautiSession {
     }
   }
 
-  async status(): Promise<{
-    port: number | null;
-    sessions: number;
-    manifest: BackgroundManifest;
-    mediaServer: string | null;
-    fish: boolean;
-    muted: boolean;
-    tone: BackgroundTone;
-  }> {
+  async status(): Promise<HostSessionStatus> {
     await this.store.init();
     const manifest = await this.store.readActiveManifest();
     return {
+      host: this.descriptor,
       port: this.port,
       sessions: this.host?.activeSessionCount ?? 0,
       manifest,

--- a/packages/core/src/apply-transaction.ts
+++ b/packages/core/src/apply-transaction.ts
@@ -192,11 +192,14 @@ export class ApplyTransaction {
     const image = await this.media.stage(imagePath);
     let video: MediaAssetHandle | null = null;
     if (manifest.background.type === "video" && manifest.background.video) {
-      const videoPath = path.join(
-        this.store.paths.activeDir,
-        manifest.background.video,
-      );
-      video = await this.media.stage(videoPath);
+      // DSH streams this handle for the lifetime of the active <video>. On
+      // Windows, serving active/background.mp4 directly keeps the active
+      // directory open and the next atomic directory swap fails with EPERM.
+      const runtimeVideoPath = await this.store.prepareRuntimeVideo(manifest);
+      if (!runtimeVideoPath) {
+        throw new Error("Video media staging requires a detached runtime copy.");
+      }
+      video = await this.media.stage(runtimeVideoPath);
     }
     return { image, video };
   }

--- a/packages/core/src/error-message.ts
+++ b/packages/core/src/error-message.ts
@@ -15,6 +15,34 @@ export function toChineseErrorMessage(value: unknown): string {
 
   const rules: Array<[RegExp, string | ((match: RegExpExecArray) => string)]> = [
     [
+      /DeepSeek Harness URL must be loopback HTTP\.?/i,
+      "DeepSeek Harness 地址必须使用本机回环 HTTP（127.0.0.1、localhost 或 ::1）。",
+    ],
+    [
+      /DeepSeek Harness phase one supports image backgrounds only\.?/i,
+      "DeepSeek Harness 第一阶段仅支持图片背景、清除和重新应用；视频、摸鱼模式、声音与色调暂不支持。",
+    ],
+    [
+      /DeepSeek Harness bridge token file is invalid\.?/i,
+      "DeepSeek Harness 桥接令牌文件无效，请删除该令牌文件后重新启动 beautiCode。",
+    ],
+    [
+      /DeepSeek Harness bridge (?:is unavailable|request failed.*|request timed out)\.?/i,
+      "未连接到 DeepSeek Harness。请先用 beautiCode 补丁启动 dsh web，并打开浏览器页面。",
+    ],
+    [
+      /No DeepSeek Harness browser client is connected\.?/i,
+      "DeepSeek Harness 页面尚未连接，请先在浏览器中打开 DSH Web。",
+    ],
+    [
+      /DeepSeek Harness client (?:has not acknowledged this generation|failed to render the background)\.?/i,
+      "DeepSeek Harness 页面未确认背景已成功显示。",
+    ],
+    [
+      /DeepSeek Harness image apply requires a loopback media URL\.?/i,
+      "无法为 DeepSeek Harness 创建安全的本机图片地址。",
+    ],
+    [
       /No healthy loopback Codex CDP endpoint found.*$/i,
       "未发现健康的本机 Codex CDP 端点，请先打开 Codex Desktop。",
     ],

--- a/packages/core/src/host-session.ts
+++ b/packages/core/src/host-session.ts
@@ -1,0 +1,45 @@
+import type { SavedThemeInfo } from "./background-store.js";
+import type {
+  ApplyInput,
+  ApplyResult,
+  BackgroundManifest,
+  BackgroundTone,
+  HostDescriptor,
+} from "./types.js";
+
+export interface HostSessionStatus {
+  host: HostDescriptor;
+  port: number | null;
+  sessions: number;
+  manifest: BackgroundManifest;
+  mediaServer: string | null;
+  fish: boolean;
+  muted: boolean;
+  tone: BackgroundTone;
+}
+
+/**
+ * Common control-plane contract. Host adapters may keep richer private APIs,
+ * but the tray only depends on this deliberately small surface.
+ */
+export interface HostSession {
+  readonly descriptor: HostDescriptor;
+  readonly cdpPort: number | null;
+  readonly isBusy: boolean;
+  readonly isOpen: boolean;
+  readonly isHostReady: boolean;
+  start(): Promise<{ port: number | null }>;
+  stop(): Promise<void>;
+  status(): Promise<HostSessionStatus>;
+  apply(input: ApplyInput): Promise<ApplyResult>;
+  reapply(): Promise<ApplyResult>;
+  saveCurrentTheme(name: string): Promise<SavedThemeInfo>;
+  listSavedThemes(): Promise<SavedThemeInfo[]>;
+  deleteSavedTheme(themeId: string): Promise<boolean>;
+  useSavedTheme(themeId: string): Promise<ApplyResult>;
+  setFishMode(enabled: boolean): Promise<{ ok: boolean }>;
+  setMuted(muted: boolean): Promise<{ ok: boolean }>;
+  setBackgroundTone(
+    tone: BackgroundTone,
+  ): Promise<{ ok: boolean }>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./constants.js";
 export * from "./types.js";
+export * from "./host-session.js";
 export * from "./media-validation.js";
 export * from "./media-server.js";
 export {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,25 @@ import { SCHEMA_ID } from "./constants.js";
 
 export type BackgroundType = "image" | "video" | "clear";
 export type BackgroundTone = "dark" | "light" | "auto";
+export type HostKind = "codex" | "dsh";
+
+export interface HostCapabilities {
+  image: boolean;
+  clear: boolean;
+  reapply: boolean;
+  savedThemes: boolean;
+  video: boolean;
+  fish: boolean;
+  muted: boolean;
+  tone: boolean;
+}
+
+/** Stable metadata used by the control plane instead of host-specific guesses. */
+export interface HostDescriptor {
+  kind: HostKind;
+  displayName: string;
+  capabilities: HostCapabilities;
+}
 
 export interface BackgroundMedia {
   type: "image" | "video";

--- a/packages/core/test/background-store.test.js
+++ b/packages/core/test/background-store.test.js
@@ -232,6 +232,16 @@ test("apply transaction offline success path", async () => {
   if (r2.ok) assert.equal(r2.mode, "video");
   assert.ok(media.activeVideo?.url.startsWith("http://127.0.0.1:"));
   assert.ok(media.activeImage?.srcUrl.includes("?t="));
+  assert.ok(
+    path.resolve(media.activeVideo.filePath).startsWith(
+      `${path.resolve(store.paths.runtimeMediaDir)}${path.sep}`,
+    ),
+  );
+  assert.ok(
+    !path.resolve(media.activeVideo.filePath).startsWith(
+      `${path.resolve(store.paths.activeDir)}${path.sep}`,
+    ),
+  );
 
   const r3 = await tx.run({ type: "clear" });
   assert.equal(r3.ok, true);

--- a/packages/core/test/error-message.test.js
+++ b/packages/core/test/error-message.test.js
@@ -18,3 +18,16 @@ test("user-facing CDP errors are localized", () => {
     "实时校验未通过（失败）：未找到视频节点。",
   );
 });
+
+test("user-facing DeepSeek Harness errors are localized", () => {
+  assert.match(
+    toChineseErrorMessage(
+      "DeepSeek Harness phase one supports image backgrounds only.",
+    ),
+    /DeepSeek Harness 第一阶段仅支持图片背景/,
+  );
+  assert.match(
+    toChineseErrorMessage("No DeepSeek Harness browser client is connected."),
+    /页面尚未连接/,
+  );
+});


### PR DESCRIPTION
## Summary
- Add shared `HostSession` / `HostDescriptor` control-plane types in `@beauticode/core`
- Make Codex `BeautiSession` implement the shared contract
- Stage detached runtime videos so Windows active-dir swaps do not hit EPERM
- Localize upcoming DeepSeek Harness error strings

## Stack
Base: `release/v0.1.4` → main

## Test plan
- [x] `npm test` / `npm run typecheck` on full stack tip
- [ ] CI green
- [ ] Codex image/video apply still works