### PR TITLE
add host picker tray flow for Codex and DeepSeek Harness

### DIFF
--- a/apps/tray/session-host.mjs
+++ b/apps/tray/session-host.mjs
@@ -35,9 +35,6 @@ if (Number(process.versions.node.split(".", 1)[0]) < 22) {
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../..");
-const adapterEntry = pathToFileURL(
-  path.resolve(repoRoot, "packages/adapter-codex/dist/index.js"),
-).href;
 
 function argValue(name) {
   const idx = process.argv.indexOf(name);
@@ -46,9 +43,20 @@ function argValue(name) {
   return value && !value.startsWith("--") ? value : null;
 }
 
+const hostKind = argValue("--host") ?? "codex";
+if (hostKind !== "codex" && hostKind !== "dsh") {
+  console.error("--host 必须是 codex 或 dsh。");
+  process.exit(1);
+}
+const adapterFolder = hostKind === "dsh" ? "adapter-dsh" : "adapter-codex";
+const adapterEntry = pathToFileURL(
+  path.resolve(repoRoot, `packages/${adapterFolder}/dist/index.js`),
+).href;
+
 const token = process.env.BEAUTICODE_CONTROL_TOKEN;
 delete process.env.BEAUTICODE_CONTROL_TOKEN;
 const portArg = argValue("--port");
+const dshUrl = argValue("--dsh-url") ?? "http://127.0.0.1:3080";
 const dataRoot = argValue("--data-root");
 const verifyMs = Number(argValue("--verify-ms") ?? "30000");
 if (!Number.isFinite(verifyMs) || verifyMs < 0 || verifyMs > 300_000) {
@@ -76,6 +84,7 @@ const sessionOpts = {
     console.error(`[session] ${msg}`);
   },
 };
+if (hostKind === "dsh") sessionOpts.baseUrl = dshUrl;
 if (portArg) {
   const p = Number(portArg);
   if (!Number.isInteger(p) || p < 1 || p > 65535) {
@@ -87,7 +96,8 @@ if (portArg) {
 }
 if (dataRoot) sessionOpts.dataRoot = path.resolve(dataRoot);
 
-const session = new adapter.BeautiSession(sessionOpts);
+const SessionClass = hostKind === "dsh" ? adapter.DshSession : adapter.BeautiSession;
+const session = new SessionClass(sessionOpts);
 let shuttingDown = false;
 
 function readBody(req, maxBytes = 64 * 1024) {
@@ -191,6 +201,7 @@ const server = http.createServer(
     if (req.method === "GET" && url === "/health") {
       send(res, 200, {
         ok: true,
+        host: session.descriptor,
         port: session.cdpPort,
         open: session.isOpen,
         busy: session.isBusy,
@@ -208,10 +219,33 @@ const server = http.createServer(
       return;
     }
     if (req.method === "GET" && url === "/guidance") {
-      send(res, 200, { ok: true, guidance: adapter.getCodexLaunchGuidance() });
+      send(res, 200, {
+        ok: true,
+        guidance:
+          hostKind === "dsh"
+            ? {
+                title: "连接 DeepSeek Harness",
+                steps: [
+                  "使用 integrations/deepseek-harness/cordis.patch.example.yml 启动 dsh web。",
+                  "在浏览器中打开 DSH Web 页面。",
+                  "回到 beautiCode 托盘选择图片。",
+                ],
+              }
+            : adapter.getCodexLaunchGuidance(),
+      });
       return;
     }
     if (req.method === "POST" && url === "/discover") {
+      if (hostKind === "dsh") {
+        const status = await session.status();
+        send(res, 200, {
+          ok: status.sessions > 0,
+          endpoints: status.sessions > 0
+            ? [{ port: status.port, browser: "DeepSeek Harness", primaryPages: status.sessions, source: "bridge" }]
+            : [],
+        });
+        return;
+      }
       const endpoints = await adapter.discoverCdpEndpoints({ requirePages: true });
       send(res, 200, {
         ok: endpoints.length > 0,
@@ -411,6 +445,7 @@ const listenPort = typeof addr === "object" && addr ? addr.port : 0;
 console.log(
   JSON.stringify({
     ready: true,
+    host: hostKind,
     controlPort: listenPort,
     cdpPort: session.cdpPort,
   }),

--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -3,10 +3,14 @@ param(
   [int]$Port = 0,
   [string]$DataRoot = "",
   [string]$NodePath = "",
+  [ValidateSet("codex", "dsh")]
+  [string]$TargetHost = "codex",
+  [string]$DshUrl = "http://127.0.0.1:3080",
   [switch]$SkipBuild
 )
 
 $ErrorActionPreference = "Stop"
+$script:targetHost = $TargetHost
 
 $script:TrayLogRoot = if ($env:LOCALAPPDATA) {
   Join-Path $env:LOCALAPPDATA "beautiCode\logs"
@@ -44,7 +48,10 @@ Write-BcTrayLog "tray starting"
 
 $script:trayInstanceMutex = $null
 $script:trayInstanceMutexOwned = $false
+$script:hostInstanceMutex = $null
+$script:hostInstanceMutexOwned = $false
 $script:showPanelEvent = $null
+$script:shutdownEvent = $null
 $script:showPanelTimer = $null
 $createdNew = $false
 $script:trayInstanceMutex = [System.Threading.Mutex]::new(
@@ -57,12 +64,26 @@ if (-not $createdNew) {
   exit 0
 }
 $script:trayInstanceMutexOwned = $true
+$hostMutexCreated = $false
+$script:hostInstanceMutex = [System.Threading.Mutex]::new(
+  $true,
+  ("Local\beautiCode.Engine.Host.{0}.v1" -f $TargetHost),
+  [ref]$hostMutexCreated
+)
+$script:hostInstanceMutexOwned = $hostMutexCreated
 $showPanelEventCreated = $false
 $script:showPanelEvent = [System.Threading.EventWaitHandle]::new(
   $false,
   [System.Threading.EventResetMode]::AutoReset,
   "Local\beautiCode.Engine.ShowPanel.v1",
   [ref]$showPanelEventCreated
+)
+$shutdownEventCreated = $false
+$script:shutdownEvent = [System.Threading.EventWaitHandle]::new(
+  $false,
+  [System.Threading.EventResetMode]::AutoReset,
+  "Local\beautiCode.Engine.Shutdown.v1",
+  [ref]$shutdownEventCreated
 )
 
 $dpiNativeCode = @'
@@ -109,7 +130,11 @@ Add-Type -TypeDefinition $dpiNativeCode -ErrorAction Stop
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 [System.Windows.Forms.Application]::EnableVisualStyles()
-[System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
+try {
+  [System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
+} catch [System.InvalidOperationException] {
+  Write-BcTrayLog "compatible text rendering was already initialized by the launcher"
+}
 
 if (-not ("BeautiCodeToggle" -as [type])) {
   $toggleCode = @'
@@ -228,12 +253,15 @@ $CodexLaunchScript = Join-Path $RepoRoot "scripts\codex-launch.ps1"
 $ReleaseManifest = Join-Path $RepoRoot "release-manifest.json"
 $BundledNode = Join-Path $RepoRoot "runtime\node.exe"
 $coreDist = Join-Path $RepoRoot "packages\core\dist\index.js"
-$adapterDist = Join-Path $RepoRoot "packages\adapter-codex\dist\index.js"
+$adapterFolder = if ($TargetHost -eq "dsh") { "adapter-dsh" } else { "adapter-codex" }
+$adapterDist = Join-Path $RepoRoot ("packages\{0}\dist\index.js" -f $adapterFolder)
 
-if (-not (Test-Path -LiteralPath $CodexLaunchScript -PathType Leaf)) {
-  throw "缺少 Codex 启动脚本：$CodexLaunchScript"
+if ($TargetHost -eq "codex") {
+  if (-not (Test-Path -LiteralPath $CodexLaunchScript -PathType Leaf)) {
+    throw "缺少 Codex 启动脚本：$CodexLaunchScript"
+  }
+  . $CodexLaunchScript
 }
-. $CodexLaunchScript
 
 if ($NodePath) {
   if (-not (Test-Path -LiteralPath $NodePath -PathType Leaf)) {
@@ -266,7 +294,7 @@ if (-not $SkipBuild) {
     $inputFiles = @()
     foreach ($inputPath in @(
         (Join-Path $RepoRoot "packages\core\src"),
-        (Join-Path $RepoRoot "packages\adapter-codex\src")
+        (Join-Path $RepoRoot ("packages\{0}\src" -f $adapterFolder))
       )) {
       $inputFiles += @(Get-ChildItem -LiteralPath $inputPath -Recurse -File)
     }
@@ -274,7 +302,7 @@ if (-not $SkipBuild) {
         (Join-Path $RepoRoot "package.json"),
         (Join-Path $RepoRoot "package-lock.json"),
         (Join-Path $RepoRoot "packages\core\package.json"),
-        (Join-Path $RepoRoot "packages\adapter-codex\package.json"),
+        (Join-Path $RepoRoot ("packages\{0}\package.json" -f $adapterFolder)),
         (Join-Path $RepoRoot "scripts\copy-renderer-assets.mjs")
       )) {
       if (Test-Path -LiteralPath $inputPath) {
@@ -322,8 +350,13 @@ function ConvertTo-PsLiteral([string]$Value) {
 
 $nodeInvocationParts = @(
   (ConvertTo-PsLiteral $Node),
-  (ConvertTo-PsLiteral $HostScript)
+  (ConvertTo-PsLiteral $HostScript),
+  "--host",
+  $TargetHost
 )
+if ($TargetHost -eq "dsh") {
+  $nodeInvocationParts += @("--dsh-url", (ConvertTo-PsLiteral $DshUrl))
+}
 if ($Port -gt 0) {
   $nodeInvocationParts += @("--port", "$Port")
 }
@@ -409,11 +442,11 @@ if (-not $ready -or -not $ready.ready) {
 }
 
 $controlPort = [int]$ready.controlPort
-$cdpPort = [int]$ready.cdpPort
+$cdpPort = if ($null -ne $ready.cdpPort) { [int]$ready.cdpPort } else { 0 }
 $script:cdpPort = $cdpPort
 $BaseUrl = "http://127.0.0.1:$controlPort"
-Write-Host ("Tray control plane {0} (CDP :{1})" -f $BaseUrl, $cdpPort)
-Write-BcTrayLog ("session-host ready controlPort={0} cdpPort={1}" -f $controlPort, $cdpPort)
+Write-Host ("Tray control plane {0} (host: {1})" -f $BaseUrl, $TargetHost)
+Write-BcTrayLog ("session-host ready host={0} controlPort={1} cdpPort={2}" -f $TargetHost, $controlPort, $cdpPort)
 
 function Invoke-BcApi {
   param(
@@ -729,6 +762,17 @@ function Wait-BcCdpReady {
 # - process up, CDP missing   → restart with CDP flags, wait, reapply
 # - process down              → start with CDP flags, wait, reapply
 function Invoke-BcEnsureHostAndReapply {
+  if ($script:targetHost -eq "dsh") {
+    $res = Invoke-BcApi -Method Post -Path "/reapply" -Body @{}
+    if ($res.ok) {
+      Show-Tip -Title $L.AppName -Text $L.ReapplyOk -Icon Info
+      return $true
+    }
+    $err = if ($res.error) { [string]$res.error } else { $L.ApplyFail }
+    Show-Tip -Title $L.AppName -Text $err -Icon Error
+    return $false
+  }
+
   $preferred = 0
   try {
     if ($script:cdpPort -gt 0) { $preferred = [int]$script:cdpPort }
@@ -873,6 +917,10 @@ $L = @{
   ForceCloseConfirm = (U "5E94 7528 672A 5728 0020 0035 0020 79D2 5185 9000 51FA 3002 662F 5426 5F3A 5236 7ED3 675F 5269 4F59 8FDB 7A0B FF1F")
   RestartCancelled = (U "5DF2 53D6 6D88 91CD 542F 3002")
   RunningTip     = (U "6258 76D8 5DF2 542F 52A8 3002 0043 0074 0072 006C 002B 0053 0068 0069 0066 0074 002B 0053 0070 0061 0063 0065 0020 6478 9C7C 3002") # 托盘已启动。Ctrl+Shift+Space 摸鱼。
+  RunningTipDsh  = (U "6258 76D8 5DF2 542F 52A8 3002 8BF7 5148 6253 5F00 0020 0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7F51 9875 3002") # 托盘已启动。请先打开 DeepSeek Harness 网页。
+  HostCodex      = "Codex Desktop"
+  HostDsh        = "DeepSeek Harness"
+  DshPhaseOne    = (U "0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7B2C 4E00 9636 6BB5 4EC5 652F 6301 56FE 7247 80CC 666F 3001 6E05 9664 548C 91CD 65B0 5E94 7528 3002") # DeepSeek Harness 第一阶段仅支持图片背景、清除和重新应用。
   FailedSuffix   = (U "5931 8D25")                                         # 失败
   MediaImage     = (U "56FE 7247")                                         # 图片
   MediaVideo     = (U "89C6 9891")                                         # 视频
@@ -971,6 +1019,7 @@ function Get-BcStatusLine {
     # Deliberately omit CDP port and generation — keep tray UX simple.
     $parts = New-Object System.Collections.ArrayList
     [void]$parts.Add($base)
+    [void]$parts.Add($(if ($script:targetHost -eq "dsh") { $L.HostDsh } else { $L.HostCodex }))
     [void]$parts.Add($mediaLabel)
     if ($script:fishMode) { [void]$parts.Add($L.FishLabel) }
     if (-not $script:videoMuted -and $mediaKey -eq "video") {
@@ -2341,6 +2390,14 @@ $script:showPanelTimer.Interval = 100
 $null = $script:showPanelTimer.add_Tick({
     try {
       if (
+        $null -ne $script:shutdownEvent -and
+        $script:shutdownEvent.WaitOne(0)
+      ) {
+        Write-BcTrayLog "shutdown event received"
+        [System.Windows.Forms.Application]::Exit()
+        return
+      }
+      if (
         $null -ne $script:showPanelEvent -and
         $script:showPanelEvent.WaitOne(0)
       ) {
@@ -2370,7 +2427,8 @@ if (-not (Register-BcFishHotkey)) {
   Show-Tip -Title $L.AppName -Text $L.HotkeyFail -Icon Warning
 }
 
-Show-Tip -Title $L.AppName -Text $L.RunningTip -Icon Info
+$runningText = if ($script:targetHost -eq "dsh") { $L.RunningTipDsh } else { $L.RunningTip }
+Show-Tip -Title $L.AppName -Text $runningText -Icon Info
 
 try {
   [System.Windows.Forms.Application]::Run()
@@ -2474,8 +2532,20 @@ try {
     try { $script:trayInstanceMutex.Dispose() } catch { }
     $script:trayInstanceMutex = $null
   }
+  if ($null -ne $script:hostInstanceMutex) {
+    if ($script:hostInstanceMutexOwned) {
+      try { $script:hostInstanceMutex.ReleaseMutex() } catch { }
+      $script:hostInstanceMutexOwned = $false
+    }
+    try { $script:hostInstanceMutex.Dispose() } catch { }
+    $script:hostInstanceMutex = $null
+  }
   if ($null -ne $script:showPanelEvent) {
     try { $script:showPanelEvent.Dispose() } catch { }
     $script:showPanelEvent = $null
+  }
+  if ($null -ne $script:shutdownEvent) {
+    try { $script:shutdownEvent.Dispose() } catch { }
+    $script:shutdownEvent = $null
   }
 }

--- a/packages/adapter-dsh/test/session-host.test.js
+++ b/packages/adapter-dsh/test/session-host.test.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const hostScript = path.resolve(here, "../../../apps/tray/session-host.mjs");
+const CONTROL_TOKEN = "control-token-for-session-host-test-123456";
+
+test("session-host starts in DSH mode without touching Codex", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "beauticode-dsh-host-"));
+  const child = spawn(
+    process.execPath,
+    [
+      hostScript,
+      "--host",
+      "dsh",
+      "--dsh-url",
+      "http://127.0.0.1:1",
+      "--data-root",
+      path.join(root, "data"),
+      "--verify-ms",
+      "20",
+    ],
+    {
+      cwd: path.resolve(here, "../../.."),
+      env: { ...process.env, BEAUTICODE_CONTROL_TOKEN: CONTROL_TOKEN },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  t.after(async () => {
+    if (child.exitCode == null) child.kill();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const ready = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`ready timeout: ${stderr}`)), 5_000);
+    const lines = readline.createInterface({ input: child.stdout });
+    lines.on("line", (line) => {
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.ready) {
+          clearTimeout(timer);
+          lines.close();
+          resolve(parsed);
+        }
+      } catch {
+        /* ignore diagnostic lines */
+      }
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`session-host exited ${code}: ${stderr}`));
+    });
+  });
+  assert.equal(ready.host, "dsh");
+  assert.equal(ready.cdpPort, null);
+
+  const headers = { Authorization: `Bearer ${CONTROL_TOKEN}` };
+  const healthResponse = await fetch(`http://127.0.0.1:${ready.controlPort}/health`, { headers });
+  assert.equal(healthResponse.status, 200);
+  const health = await healthResponse.json();
+  assert.equal(health.host.kind, "dsh");
+  assert.equal(health.port, null);
+
+  const shutdown = await fetch(`http://127.0.0.1:${ready.controlPort}/shutdown`, {
+    method: "POST",
+    headers: { ...headers, "content-type": "application/json" },
+    body: "{}",
+  });
+  assert.equal(shutdown.status, 200);
+  await new Promise((resolve) => child.once("exit", resolve));
+  assert.equal(child.exitCode, 0, stderr);
+});

--- a/scripts/start-beauticode-dsh.ps1
+++ b/scripts/start-beauticode-dsh.ps1
@@ -1,0 +1,394 @@
+﻿#Requires -Version 5.1
+param(
+  [string]$DshUrl = "http://127.0.0.1:3080",
+  [string]$DataRoot = "",
+  [switch]$SkipBuild,
+  [switch]$NoBrowser,
+  [switch]$EnsureBridgeOnly,
+  [string]$DshCommand = "",
+  [switch]$VersionOnly,
+  [switch]$NoVersionCheck
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$trayScript = Join-Path $repoRoot "apps\tray\start-tray.ps1"
+$pluginSourceRoot = Join-Path $repoRoot "integrations\deepseek-harness"
+$compatibilityFile = Join-Path $pluginSourceRoot "compatibility.json"
+$runtimeInstaller = Join-Path $repoRoot "scripts\install-dsh-runtime.ps1"
+
+if (-not (Test-Path -LiteralPath $compatibilityFile -PathType Leaf)) {
+  throw "缺少 DSH 兼容性清单：$compatibilityFile"
+}
+$compatibility = Get-Content -Raw -LiteralPath $compatibilityFile | ConvertFrom-Json
+if ($compatibility.schema -ne "beauticode.dsh-compatibility/v1") {
+  throw "DSH 兼容性清单版本无效。"
+}
+$supportedVersion = [string]$compatibility.supportedVersion
+$bridgeProtocol = [int]$compatibility.bridgeProtocol
+
+function ConvertTo-BcDshUrl {
+  param([string]$Value)
+  $uri = [Uri]$Value
+  if (
+    $uri.Scheme -ne "http" -or
+    $uri.Host -notin @("127.0.0.1", "localhost", "::1") -or
+    $uri.UserInfo -or
+    ($uri.AbsolutePath -and $uri.AbsolutePath -ne "/") -or
+    $uri.Query -or
+    $uri.Fragment
+  ) {
+    throw "DSH 地址必须是本机 HTTP 根地址，例如 http://127.0.0.1:3080。"
+  }
+  return $uri
+}
+
+function Get-BcFileSha256 {
+  param([string]$Path)
+  $stream = $null
+  $sha = [Security.Cryptography.SHA256]::Create()
+  try {
+    $stream = [IO.File]::OpenRead($Path)
+    return ([BitConverter]::ToString($sha.ComputeHash($stream))).Replace("-", "").ToLowerInvariant()
+  } finally {
+    if ($null -ne $stream) { $stream.Dispose() }
+    $sha.Dispose()
+  }
+}
+
+function Get-BcBridgeRevision {
+  param([string]$SourceRoot)
+  $parts = @()
+  foreach ($name in @("index.mjs", "client.js")) {
+    $file = Join-Path $SourceRoot $name
+    if (-not (Test-Path -LiteralPath $file -PathType Leaf)) {
+      throw "DSH 桥接文件缺失：$file"
+    }
+    $parts += ("{0}:{1}" -f $name, (Get-BcFileSha256 -Path $file))
+  }
+  $sha = [Security.Cryptography.SHA256]::Create()
+  try {
+    $digest = $sha.ComputeHash([Text.Encoding]::UTF8.GetBytes(($parts -join "`n")))
+    return -join ($digest | ForEach-Object { $_.ToString("x2") })
+  } finally {
+    $sha.Dispose()
+  }
+}
+
+function Install-BcBridgeRevision {
+  param([string]$SourceRoot, [string]$EffectiveDshHome)
+  $revision = Get-BcBridgeRevision -SourceRoot $SourceRoot
+  $versionsRoot = Join-Path $EffectiveDshHome "beauticode-bridge\versions"
+  $targetRoot = Join-Path $versionsRoot $revision
+  $targetIndex = Join-Path $targetRoot "index.mjs"
+  if (Test-Path -LiteralPath $targetRoot -PathType Container) {
+    if ((Get-BcBridgeRevision -SourceRoot $targetRoot) -ne $revision) {
+      throw "已发布的 DSH 桥接版本内容已损坏：$targetRoot"
+    }
+    return [pscustomobject]@{ Revision = $revision; Index = $targetIndex; Root = $targetRoot }
+  }
+
+  [IO.Directory]::CreateDirectory($versionsRoot) | Out-Null
+  $stagingRoot = Join-Path $versionsRoot (".staging-{0}-{1}" -f $PID, [guid]::NewGuid().ToString("N"))
+  try {
+    [IO.Directory]::CreateDirectory($stagingRoot) | Out-Null
+    Copy-Item -LiteralPath (Join-Path $SourceRoot "index.mjs") -Destination $stagingRoot
+    Copy-Item -LiteralPath (Join-Path $SourceRoot "client.js") -Destination $stagingRoot
+    $manifest = [ordered]@{
+      schema = "beauticode.dsh-bridge/v1"
+      protocol = $bridgeProtocol
+      revision = $revision
+      publishedAtUtc = [DateTime]::UtcNow.ToString("o")
+    }
+    [IO.File]::WriteAllText(
+      (Join-Path $stagingRoot "bridge-manifest.json"),
+      ($manifest | ConvertTo-Json),
+      (New-Object Text.UTF8Encoding($false))
+    )
+    try {
+      Move-Item -LiteralPath $stagingRoot -Destination $targetRoot
+    } catch {
+      if (-not (Test-Path -LiteralPath $targetRoot -PathType Container)) { throw }
+    }
+  } finally {
+    if (Test-Path -LiteralPath $stagingRoot) {
+      Remove-Item -LiteralPath $stagingRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+  return [pscustomobject]@{ Revision = $revision; Index = $targetIndex; Root = $targetRoot }
+}
+
+function Get-BcDshBridgeInfo {
+  param([Uri]$BaseUri)
+  try {
+    $probe = Invoke-RestMethod -UseBasicParsing -Uri ([Uri]::new($BaseUri, "/__beauticode/version")) -TimeoutSec 2
+    if ($probe.ok -eq $true -and $probe.protocol -is [int] -and $probe.revision -is [string]) {
+      return $probe
+    }
+  } catch {}
+  return $null
+}
+
+function Test-BcDshServer {
+  param([Uri]$BaseUri)
+  $client = New-Object Net.Sockets.TcpClient
+  try {
+    $connect = $client.BeginConnect($BaseUri.Host, $BaseUri.Port, $null, $null)
+    if (-not $connect.AsyncWaitHandle.WaitOne(750)) { return $false }
+    $client.EndConnect($connect)
+    return $client.Connected
+  } catch {
+    return $false
+  } finally {
+    $client.Dispose()
+  }
+}
+
+function Get-BcNodePath {
+  $bundled = Join-Path $repoRoot "runtime\node.exe"
+  if (Test-Path -LiteralPath $bundled -PathType Leaf) { return $bundled }
+  $node = Get-Command node.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+  if ($node) { return $node.Source }
+  return $null
+}
+
+function Get-BcRuntimeFromRoot {
+  param([string]$RuntimeRoot, [string]$NodePath, [string]$Source)
+  $manifestPath = Join-Path $RuntimeRoot "current.json"
+  if (-not $NodePath -or -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) { return $null }
+  try {
+    $manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+    if (
+      $manifest.schema -ne "beauticode.dsh-runtime/v1" -or
+      $manifest.package -ne [string]$compatibility.package -or
+      $manifest.version -ne $supportedVersion -or
+      $manifest.integrity -ne [string]$compatibility.integrity
+    ) { return $null }
+    $cli = [string]$manifest.cli
+    if (-not [IO.Path]::IsPathRooted($cli)) { $cli = Join-Path $RuntimeRoot $cli }
+    if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) { return $null }
+    $output = @(& $NodePath $cli --version 2>&1)
+    $version = ([string]($output | Select-Object -First 1)).Trim()
+    if ($LASTEXITCODE -ne 0 -or $version -ne $supportedVersion) { return $null }
+    return [pscustomobject]@{
+      FilePath = $NodePath
+      Arguments = @('"{0}"' -f $cli.Replace('"', '\"'))
+      Version = $version
+      Source = $Source
+      Root = $RuntimeRoot
+    }
+  } catch {
+    return $null
+  }
+}
+
+function Get-BcDshRuntime {
+  param([string]$PrivateRuntimeRoot, [switch]$AllowInstall)
+  if ($DshCommand) {
+    if (-not (Test-Path -LiteralPath $DshCommand -PathType Leaf)) {
+      throw "指定的 DSH 命令不存在：$DshCommand"
+    }
+    $command = (Resolve-Path -LiteralPath $DshCommand).Path
+    $output = @(& $command --version 2>&1)
+    $version = ([string]($output | Select-Object -First 1)).Trim()
+    if ($LASTEXITCODE -ne 0 -or $version -ne $supportedVersion) {
+      throw "指定的 DSH 版本不兼容：需要 $supportedVersion，实际 $version。"
+    }
+    return [pscustomobject]@{
+      FilePath = $command; Arguments = @(); Version = $version; Source = "override"; Root = ""
+    }
+  }
+
+  $nodePath = Get-BcNodePath
+  $bundledRoot = Join-Path $repoRoot "runtime\dsh"
+  $runtime = Get-BcRuntimeFromRoot -RuntimeRoot $bundledRoot -NodePath $nodePath -Source "bundled"
+  if ($runtime) { return $runtime }
+  $runtime = Get-BcRuntimeFromRoot -RuntimeRoot $PrivateRuntimeRoot -NodePath $nodePath -Source "private"
+  if ($runtime -or -not $AllowInstall) { return $runtime }
+
+  if (-not $nodePath) { throw "未找到 Node.js，无法创建 beautiCode 私有 DSH 运行时。" }
+  $npm = Get-Command npm.cmd -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $npm) { throw "未找到 npm.cmd，无法创建 beautiCode 私有 DSH 运行时。" }
+  & $runtimeInstaller `
+    -InstallRoot $PrivateRuntimeRoot `
+    -CompatibilityFile $compatibilityFile `
+    -NodeCommand $nodePath `
+    -NpmCommand $npm.Source
+  $runtime = Get-BcRuntimeFromRoot -RuntimeRoot $PrivateRuntimeRoot -NodePath $nodePath -Source "private"
+  if (-not $runtime) { throw "DSH 私有运行时安装后校验失败。" }
+  return $runtime
+}
+
+function Get-BcLatestDshVersion {
+  param([string]$EffectiveDataRoot)
+  if ($NoVersionCheck) { return $null }
+  $cachePath = Join-Path $EffectiveDataRoot "dsh-version-check.json"
+  try {
+    if (Test-Path -LiteralPath $cachePath -PathType Leaf) {
+      $cache = Get-Content -Raw -LiteralPath $cachePath | ConvertFrom-Json
+      $checkedAt = [DateTime]::Parse([string]$cache.checkedAtUtc).ToUniversalTime()
+      if ([DateTime]::UtcNow - $checkedAt -lt [TimeSpan]::FromHours(24)) {
+        return [string]$cache.latestVersion
+      }
+    }
+  } catch {}
+  try {
+    $latest = Invoke-RestMethod -UseBasicParsing -Uri "https://registry.npmjs.org/@deepseek-ai%2fdsh/latest" -TimeoutSec 5
+    $version = [string]$latest.version
+    if ($version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') { return $null }
+    [IO.Directory]::CreateDirectory($EffectiveDataRoot) | Out-Null
+    $cache = [ordered]@{
+      schema = "beauticode.dsh-version-check/v1"
+      latestVersion = $version
+      checkedAtUtc = [DateTime]::UtcNow.ToString("o")
+    }
+    [IO.File]::WriteAllText($cachePath, ($cache | ConvertTo-Json), (New-Object Text.UTF8Encoding($false)))
+    return $version
+  } catch {
+    return $null
+  }
+}
+
+function New-BcDshPatch {
+  param([string]$BridgePluginPath, [string]$Revision)
+  $patchRoot = Join-Path ([IO.Path]::GetTempPath()) "beautiCode\dsh-patches"
+  [IO.Directory]::CreateDirectory($patchRoot) | Out-Null
+  $patchPath = Join-Path $patchRoot ("beauticode-bridge-{0}.yml" -f $Revision)
+  $pluginUri = ([Uri](Resolve-Path -LiteralPath $BridgePluginPath).Path).AbsoluteUri
+  $content = @(
+    "- insert:"
+    "    - id: beauticode-bridge"
+    ("      name: '{0}'" -f $pluginUri.Replace("'", "''"))
+    "      inject: [webServer]"
+    ""
+  ) -join "`r`n"
+  [IO.File]::WriteAllText($patchPath, $content, (New-Object Text.UTF8Encoding($false)))
+  return $patchPath
+}
+
+function Start-BcDshBridge {
+  param(
+    [Uri]$BaseUri,
+    [pscustomobject]$Bridge,
+    [pscustomobject]$Runtime,
+    [string]$EffectiveDataRoot,
+    [string]$EffectiveDshHome
+  )
+  $port = if ($BaseUri.IsDefaultPort) { 80 } else { $BaseUri.Port }
+  $patchPath = New-BcDshPatch -BridgePluginPath $Bridge.Index -Revision $Bridge.Revision
+  $quotedPatchPath = '"{0}"' -f $patchPath.Replace('"', '\"')
+  $arguments = @($Runtime.Arguments) + @("web", "--patch", $quotedPatchPath, "--port", [string]$port)
+
+  $logRoot = Join-Path ([IO.Path]::GetTempPath()) "beautiCode\dsh-logs"
+  [IO.Directory]::CreateDirectory($logRoot) | Out-Null
+  $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $stdout = Join-Path $logRoot ("dsh-{0}.out.log" -f $stamp)
+  $stderr = Join-Path $logRoot ("dsh-{0}.err.log" -f $stamp)
+  $oldDataRoot = $env:BEAUTICODE_DATA_ROOT
+  $oldDshHome = $env:DSH_HOME
+  $processEnvironment = [Environment]::GetEnvironmentVariables()
+  $pathKeys = @($processEnvironment.Keys | Where-Object { $_ -ieq "path" })
+  $duplicatePath = $pathKeys.Count -gt 1 -and $pathKeys -contains "PATH"
+  $oldUpperPath = if ($duplicatePath) { $processEnvironment["PATH"] } else { $null }
+  try {
+    if ($duplicatePath) { [Environment]::SetEnvironmentVariable("PATH", $null, "Process") }
+    $env:BEAUTICODE_DATA_ROOT = $EffectiveDataRoot
+    $env:DSH_HOME = $EffectiveDshHome
+    $process = Start-Process `
+      -FilePath $Runtime.FilePath `
+      -ArgumentList $arguments `
+      -WorkingDirectory $repoRoot `
+      -WindowStyle Hidden `
+      -RedirectStandardOutput $stdout `
+      -RedirectStandardError $stderr `
+      -PassThru
+  } finally {
+    if ($null -eq $oldDataRoot) { Remove-Item Env:BEAUTICODE_DATA_ROOT -ErrorAction SilentlyContinue } else { $env:BEAUTICODE_DATA_ROOT = $oldDataRoot }
+    if ($null -eq $oldDshHome) { Remove-Item Env:DSH_HOME -ErrorAction SilentlyContinue } else { $env:DSH_HOME = $oldDshHome }
+    if ($duplicatePath) { [Environment]::SetEnvironmentVariable("PATH", $oldUpperPath, "Process") }
+  }
+
+  Write-Host ("正在启动 DeepSeek Harness {0}（PID {1}）……" -f $Runtime.Version, $process.Id)
+  $deadline = (Get-Date).AddSeconds(300)
+  while ((Get-Date) -lt $deadline) {
+    $identity = Get-BcDshBridgeInfo -BaseUri $BaseUri
+    if ($identity -and $identity.protocol -eq $bridgeProtocol -and $identity.revision -eq $Bridge.Revision) {
+      return [pscustomobject]@{ Process = $process; Stdout = $stdout; Stderr = $stderr }
+    }
+    if ($process.HasExited) {
+      $process.Refresh()
+      $rawDetail = if (Test-Path -LiteralPath $stderr) { Get-Content -Raw -LiteralPath $stderr } else { "" }
+      $detail = if ($rawDetail) { $rawDetail.Trim() } else { "" }
+      throw ("DeepSeek Harness 启动失败（退出码 {0}）。{1}`n日志：{2}" -f $process.ExitCode, $detail, $stderr)
+    }
+    Start-Sleep -Milliseconds 500
+  }
+  throw ("等待 DeepSeek Harness 桥接超时。日志：{0} / {1}" -f $stdout, $stderr)
+}
+
+$baseUri = ConvertTo-BcDshUrl -Value $DshUrl
+$effectiveDataRoot = if ($DataRoot) {
+  [IO.Path]::GetFullPath($DataRoot)
+} elseif ($env:LOCALAPPDATA) {
+  Join-Path $env:LOCALAPPDATA "beautiCode"
+} else {
+  Join-Path $env:APPDATA "beautiCode"
+}
+$effectiveDshHome = "{0}-dsh-home" -f $effectiveDataRoot.TrimEnd("\", "/")
+$privateRuntimeRoot = Join-Path $effectiveDataRoot "dsh-runtime"
+$runtime = Get-BcDshRuntime -PrivateRuntimeRoot $privateRuntimeRoot -AllowInstall:(-not $VersionOnly)
+$latestVersion = Get-BcLatestDshVersion -EffectiveDataRoot $effectiveDataRoot
+
+if ($VersionOnly) {
+  $runningBridge = Get-BcDshBridgeInfo -BaseUri $baseUri
+  [pscustomobject]@{
+    schema = "beauticode.dsh-version/v1"
+    supportedVersion = $supportedVersion
+    installedVersion = if ($runtime) { $runtime.Version } else { $null }
+    installedSource = if ($runtime) { $runtime.Source } else { $null }
+    latestVersion = $latestVersion
+    updateAvailable = [bool]($latestVersion -and $latestVersion -ne $supportedVersion)
+    bridgeProtocol = $bridgeProtocol
+    runningBridge = $runningBridge
+  } | ConvertTo-Json -Depth 5
+  return
+}
+
+if (-not $runtime) { throw "未找到兼容的 DeepSeek Harness $supportedVersion 运行时。" }
+$bridge = Install-BcBridgeRevision -SourceRoot $pluginSourceRoot -EffectiveDshHome $effectiveDshHome
+
+Write-Host "beautiCode · DeepSeek Harness"
+Write-Host ("DSH {0}（{1}）；桥接协议 {2}，版本 {3}。" -f $runtime.Version, $runtime.Source, $bridgeProtocol, $bridge.Revision.Substring(0, 12))
+if ($latestVersion -and $latestVersion -ne $supportedVersion) {
+  Write-Warning ("检测到 npm 最新 DSH {0}；当前兼容版本仍为 {1}，不会自动升级未经验证的 DSH。" -f $latestVersion, $supportedVersion)
+}
+
+$runningBridge = Get-BcDshBridgeInfo -BaseUri $baseUri
+if ($runningBridge) {
+  if ($runningBridge.protocol -eq $bridgeProtocol -and $runningBridge.revision -eq $bridge.Revision) {
+    Write-Host ("复用已加载当前 beautiCode 桥接的 DSH：{0}" -f $baseUri.AbsoluteUri)
+  } else {
+    throw ("目标地址正在运行旧版 beautiCode 桥接（协议 {0}，版本 {1}）。插件已更新到 {2}，但为避免中断现有会话不会自动重启；请关闭该 DSH 后重新运行此启动器。" -f $runningBridge.protocol, $runningBridge.revision, $bridge.Revision.Substring(0, 12))
+  }
+} elseif (Test-BcDshServer -BaseUri $baseUri) {
+  throw "目标地址已有 DeepSeek Harness，但未加载 beautiCode 桥接。为避免中断现有会话，脚本不会自动重启；请关闭该 DSH 后重新运行此启动器。"
+} else {
+  $started = Start-BcDshBridge `
+    -BaseUri $baseUri `
+    -Bridge $bridge `
+    -Runtime $runtime `
+    -EffectiveDataRoot $effectiveDataRoot `
+    -EffectiveDshHome $effectiveDshHome
+  Write-Host ("DeepSeek Harness 桥接已就绪；退出托盘时不会自动结束该进程。日志：{0}" -f $started.Stdout)
+}
+
+if ($EnsureBridgeOnly) { return }
+if (-not $NoBrowser) { Start-Process -FilePath $baseUri.AbsoluteUri | Out-Null }
+
+$arguments = @{
+  TargetHost = "dsh"
+  DshUrl = $baseUri.AbsoluteUri
+  SkipBuild = $SkipBuild
+  DataRoot = $effectiveDataRoot
+}
+& $trayScript @arguments

--- a/scripts/start-beauticode.ps1
+++ b/scripts/start-beauticode.ps1
@@ -1,0 +1,508 @@
+﻿#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Choose which host beautiCode should control.
+
+.DESCRIPTION
+  The normal beautiCode shortcut opens a small host picker, then delegates to
+  the existing Codex or DeepSeek Harness launcher. Direct launchers remain
+  available for automation and Windows logon startup.
+#>
+[CmdletBinding()]
+param(
+  [ValidateSet("prompt", "codex", "dsh")]
+  [string]$TargetHost = "prompt",
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$codexLauncher = Join-Path $repoRoot "scripts\start-beauticode-engine.ps1"
+$dshLauncher = Join-Path $repoRoot "scripts\start-beauticode-dsh.ps1"
+$iconPath = Join-Path $repoRoot "beauticode.ico"
+$brandImagePath = Join-Path $repoRoot "assets\beauticode-icon-borderless.png"
+
+function Show-BcHostPicker {
+  Add-Type -AssemblyName System.Windows.Forms
+  Add-Type -AssemblyName System.Drawing
+  if (-not ("BeautiCodeHostPickerNative" -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class BeautiCodeHostPickerNative {
+  private static readonly IntPtr PerMonitorAwareV2 = new IntPtr(-4);
+  [DllImport("user32.dll", SetLastError = true)]
+  private static extern bool SetProcessDpiAwarenessContext(IntPtr value);
+  [DllImport("user32.dll")]
+  private static extern bool SetProcessDPIAware();
+  [DllImport("user32.dll")]
+  public static extern bool ShowWindow(IntPtr hWnd, int command);
+  [DllImport("user32.dll")]
+  public static extern bool SetForegroundWindow(IntPtr hWnd);
+  [DllImport("user32.dll")]
+  public static extern bool ReleaseCapture();
+  [DllImport("user32.dll")]
+  public static extern IntPtr SendMessage(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam);
+  public static bool EnableDpi() {
+    try {
+      if (SetProcessDpiAwarenessContext(PerMonitorAwareV2)) return true;
+    } catch (EntryPointNotFoundException) { }
+    try { return SetProcessDPIAware(); } catch { return false; }
+  }
+}
+'@
+  }
+  [void][BeautiCodeHostPickerNative]::EnableDpi()
+  [System.Windows.Forms.Application]::EnableVisualStyles()
+  try {
+    [System.Windows.Forms.Application]::SetCompatibleTextRenderingDefault($false)
+  } catch [System.InvalidOperationException] {
+    # The setting is process-wide and may already be locked by another WinForms window.
+  }
+
+  $colors = @{
+    Window = [System.Drawing.ColorTranslator]::FromHtml("#1E201D")
+    Panel = [System.Drawing.ColorTranslator]::FromHtml("#242723")
+    PanelSelected = [System.Drawing.ColorTranslator]::FromHtml("#2D332E")
+    Hover = [System.Drawing.ColorTranslator]::FromHtml("#30362F")
+    Line = [System.Drawing.ColorTranslator]::FromHtml("#454942")
+    Text = [System.Drawing.ColorTranslator]::FromHtml("#F1EEE7")
+    Muted = [System.Drawing.ColorTranslator]::FromHtml("#9CA198")
+    Jade = [System.Drawing.ColorTranslator]::FromHtml("#86AA91")
+    JadeDeep = [System.Drawing.ColorTranslator]::FromHtml("#496854")
+    Copper = [System.Drawing.ColorTranslator]::FromHtml("#B98265")
+  }
+  $brandFont = New-Object System.Drawing.Font("Microsoft YaHei UI", 15, [System.Drawing.FontStyle]::Bold, [System.Drawing.GraphicsUnit]::Point)
+  $titleFont = New-Object System.Drawing.Font("Microsoft YaHei UI", 12, [System.Drawing.FontStyle]::Bold, [System.Drawing.GraphicsUnit]::Point)
+  $bodyStrongFont = New-Object System.Drawing.Font("Microsoft YaHei UI", 10.5, [System.Drawing.FontStyle]::Bold, [System.Drawing.GraphicsUnit]::Point)
+  $bodyFont = New-Object System.Drawing.Font("Microsoft YaHei UI", 9.5, [System.Drawing.FontStyle]::Regular, [System.Drawing.GraphicsUnit]::Point)
+  $metaFont = New-Object System.Drawing.Font("Microsoft YaHei UI", 9.5, [System.Drawing.FontStyle]::Regular, [System.Drawing.GraphicsUnit]::Point)
+  $sectionFont = New-Object System.Drawing.Font("Microsoft YaHei UI", 9, [System.Drawing.FontStyle]::Regular, [System.Drawing.GraphicsUnit]::Point)
+  $ownedFonts = @($brandFont, $titleFont, $bodyStrongFont, $bodyFont, $metaFont, $sectionFont)
+  $brandImage = $null
+
+  function Set-BcPickerRoundedRegion {
+    param(
+      [System.Windows.Forms.Control]$Control,
+      [int]$Radius
+    )
+    if ($Control.Width -le 0 -or $Control.Height -le 0) { return }
+    $diameter = [Math]::Max(2, $Radius * 2)
+    $path = New-Object System.Drawing.Drawing2D.GraphicsPath
+    try {
+      $path.AddArc(0, 0, $diameter, $diameter, 180, 90)
+      $path.AddArc($Control.Width - $diameter, 0, $diameter, $diameter, 270, 90)
+      $path.AddArc($Control.Width - $diameter, $Control.Height - $diameter, $diameter, $diameter, 0, 90)
+      $path.AddArc(0, $Control.Height - $diameter, $diameter, $diameter, 90, 90)
+      $path.CloseFigure()
+      $oldRegion = $Control.Region
+      $Control.Region = New-Object System.Drawing.Region($path)
+      if ($null -ne $oldRegion) { $oldRegion.Dispose() }
+    } finally {
+      $path.Dispose()
+    }
+  }
+
+  function New-BcPickerLabel {
+    param(
+      [string]$Text,
+      [int]$X,
+      [int]$Y,
+      [int]$Width,
+      [int]$Height,
+      [System.Drawing.Font]$Font,
+      [System.Drawing.Color]$Color,
+      [System.Drawing.ContentAlignment]$Align = [System.Drawing.ContentAlignment]::MiddleLeft
+    )
+    $label = New-Object System.Windows.Forms.Label
+    $label.Text = $Text
+    $label.Location = New-Object System.Drawing.Point($X, $Y)
+    $label.Size = New-Object System.Drawing.Size($Width, $Height)
+    $label.Font = $Font
+    $label.ForeColor = $Color
+    $label.BackColor = [System.Drawing.Color]::Transparent
+    $label.TextAlign = $Align
+    $label.UseCompatibleTextRendering = $false
+    return $label
+  }
+
+  $form = New-Object System.Windows.Forms.Form
+  $form.Text = "beautiCode"
+  $form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
+  $form.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::None
+  $form.ClientSize = New-Object System.Drawing.Size(520, 320)
+  $form.MaximizeBox = $false
+  $form.MinimizeBox = $false
+  $form.ShowInTaskbar = $true
+  $form.TopMost = $true
+  $form.KeyPreview = $true
+  $form.AutoScaleMode = [System.Windows.Forms.AutoScaleMode]::Dpi
+  $form.BackColor = $colors.Line
+  $form.Padding = New-Object System.Windows.Forms.Padding(1)
+  if (Test-Path -LiteralPath $iconPath -PathType Leaf) {
+    try { $form.Icon = New-Object System.Drawing.Icon($iconPath) } catch {}
+  }
+
+  $root = New-Object System.Windows.Forms.Panel
+  $root.Dock = [System.Windows.Forms.DockStyle]::Fill
+  $root.BackColor = $colors.Window
+  [void]$form.Controls.Add($root)
+
+  $header = New-Object System.Windows.Forms.Panel
+  $header.Location = New-Object System.Drawing.Point(0, 0)
+  $header.Size = New-Object System.Drawing.Size(518, 92)
+  $header.BackColor = $colors.Panel
+  [void]$root.Controls.Add($header)
+
+  $mark = New-Object System.Windows.Forms.Panel
+  $mark.Location = New-Object System.Drawing.Point(20, 19)
+  $mark.Size = New-Object System.Drawing.Size(54, 54)
+  $mark.BackColor = $colors.Window
+  [void]$header.Controls.Add($mark)
+  Set-BcPickerRoundedRegion -Control $mark -Radius 14
+  if (Test-Path -LiteralPath $brandImagePath -PathType Leaf) {
+    try {
+      $brandImage = [System.Drawing.Image]::FromFile($brandImagePath)
+      $picture = New-Object System.Windows.Forms.PictureBox
+      $picture.Location = New-Object System.Drawing.Point(7, 7)
+      $picture.Size = New-Object System.Drawing.Size(40, 40)
+      $picture.SizeMode = [System.Windows.Forms.PictureBoxSizeMode]::Zoom
+      $picture.Image = $brandImage
+      [void]$mark.Controls.Add($picture)
+    } catch { }
+  }
+  if ($mark.Controls.Count -eq 0) {
+    $fallbackMark = New-BcPickerLabel -Text "美" -X 0 -Y 0 -Width 54 -Height 54 `
+      -Font $brandFont -Color $colors.Jade -Align ([System.Drawing.ContentAlignment]::MiddleCenter)
+    [void]$mark.Controls.Add($fallbackMark)
+  }
+
+  $brand = New-BcPickerLabel -Text "beautiCode" -X 88 -Y 17 -Width 220 -Height 30 `
+    -Font $brandFont -Color $colors.Text
+  [void]$header.Controls.Add($brand)
+  $eyebrow = New-BcPickerLabel -Text "LOCAL APPEARANCE ENGINE" -X 89 -Y 47 -Width 230 -Height 21 `
+    -Font $sectionFont -Color $colors.Jade
+  [void]$header.Controls.Add($eyebrow)
+
+  $currentHost = Get-BcRunningHost
+  $statusText = if ($currentHost -eq "dsh") {
+    "● 已连接 DeepSeek Harness"
+  } elseif ($currentHost -eq "codex") {
+    "● 已连接 Codex Desktop"
+  } else {
+    "● 本地引擎待连接"
+  }
+  $statusColor = if ($currentHost) { $colors.Jade } else { $colors.Muted }
+  $status = New-BcPickerLabel -Text $statusText -X 314 -Y 19 -Width 184 -Height 25 `
+    -Font $sectionFont -Color $statusColor -Align ([System.Drawing.ContentAlignment]::MiddleRight)
+  [void]$header.Controls.Add($status)
+
+  $title = New-BcPickerLabel -Text "选择本次控制目标" -X 20 -Y 105 -Width 250 -Height 29 `
+    -Font $titleFont -Color $colors.Text
+  [void]$root.Controls.Add($title)
+  $hint = New-BcPickerLabel -Text "点击后立即启动" -X 350 -Y 107 -Width 148 -Height 25 `
+    -Font $sectionFont -Color $colors.Muted -Align ([System.Drawing.ContentAlignment]::MiddleRight)
+  [void]$root.Controls.Add($hint)
+
+  function Add-BcHostCard {
+    param(
+      [string]$CardHost,
+      [string]$Title,
+      [string]$Description,
+      [string]$Action,
+      [int]$X,
+      [bool]$Current
+    )
+    $outer = New-Object System.Windows.Forms.Panel
+    $outer.Location = New-Object System.Drawing.Point($X, 140)
+    $outer.Size = New-Object System.Drawing.Size(232, 116)
+    $outer.BackColor = if ($Current) { $colors.JadeDeep } else { $colors.Line }
+    $outer.Cursor = [System.Windows.Forms.Cursors]::Hand
+    Set-BcPickerRoundedRegion -Control $outer -Radius 12
+
+    $inner = New-Object System.Windows.Forms.Panel
+    $inner.Location = New-Object System.Drawing.Point(1, 1)
+    $inner.Size = New-Object System.Drawing.Size(230, 114)
+    $inner.BackColor = if ($Current) { $colors.PanelSelected } else { $colors.Panel }
+    $inner.Cursor = [System.Windows.Forms.Cursors]::Hand
+    Set-BcPickerRoundedRegion -Control $inner -Radius 11
+    [void]$outer.Controls.Add($inner)
+
+    $titleWidth = if ($Current) { 148 } else { 198 }
+    $titleLabel = New-BcPickerLabel -Text $Title -X 14 -Y 12 -Width $titleWidth -Height 24 `
+      -Font $bodyStrongFont -Color $colors.Text
+    $descriptionLabel = New-BcPickerLabel -Text $Description -X 14 -Y 39 -Width 196 -Height 43 `
+      -Font $metaFont -Color $colors.Muted
+    $actionLabel = New-BcPickerLabel -Text $Action -X 132 -Y 83 -Width 78 -Height 20 `
+      -Font $sectionFont -Color $colors.Jade -Align ([System.Drawing.ContentAlignment]::MiddleRight)
+    [void]$inner.Controls.Add($titleLabel)
+    [void]$inner.Controls.Add($descriptionLabel)
+    [void]$inner.Controls.Add($actionLabel)
+
+    $badge = $null
+    if ($Current) {
+      $badge = New-Object System.Windows.Forms.Panel
+      $badge.Location = New-Object System.Drawing.Point(170, 11)
+      $badge.Size = New-Object System.Drawing.Size(46, 22)
+      $badge.BackColor = $colors.Window
+      Set-BcPickerRoundedRegion -Control $badge -Radius 10
+      $badgeLabel = New-BcPickerLabel -Text "当前" -X 0 -Y 0 -Width 46 -Height 22 `
+        -Font $sectionFont -Color $colors.Jade -Align ([System.Drawing.ContentAlignment]::MiddleCenter)
+      [void]$badge.Controls.Add($badgeLabel)
+      [void]$inner.Controls.Add($badge)
+    }
+
+    # Event callbacks run after this helper scope exits, so capture concrete
+    # objects instead of resolving parent-scope variables at hover/click time.
+    $pickerForm = $form
+    $hoverBorderColor = $colors.Jade
+    $hoverSurfaceColor = $colors.Hover
+    $restBorderColor = if ($Current) { $colors.JadeDeep } else { $colors.Line }
+    $restSurfaceColor = if ($Current) { $colors.PanelSelected } else { $colors.Panel }
+    $selectHost = {
+      $pickerForm.Tag = $CardHost
+      $pickerForm.DialogResult = [System.Windows.Forms.DialogResult]::OK
+      $pickerForm.Close()
+    }.GetNewClosure()
+    $showHover = {
+      $outer.BackColor = $hoverBorderColor
+      $inner.BackColor = $hoverSurfaceColor
+    }.GetNewClosure()
+    $clearHover = {
+      $cursorPoint = $outer.PointToClient([System.Windows.Forms.Cursor]::Position)
+      if (-not $outer.ClientRectangle.Contains($cursorPoint)) {
+        $outer.BackColor = $restBorderColor
+        $inner.BackColor = $restSurfaceColor
+      }
+    }.GetNewClosure()
+    $interactiveControls = @($outer, $inner, $titleLabel, $descriptionLabel, $actionLabel)
+    if ($null -ne $badge) { $interactiveControls += @($badge, $badge.Controls[0]) }
+    foreach ($control in $interactiveControls) {
+      $control.Cursor = [System.Windows.Forms.Cursors]::Hand
+      $null = $control.add_Click($selectHost)
+      $null = $control.add_MouseEnter($showHover)
+      $null = $control.add_MouseLeave($clearHover)
+    }
+    [void]$root.Controls.Add($outer)
+  }
+
+  Add-BcHostCard -CardHost "codex" -Title "Codex Desktop" `
+    -Description "连接 Codex 桌面端，应用背景与显示控制。" -Action "启动 →" `
+    -X 20 -Current ($currentHost -eq "codex")
+  Add-BcHostCard -CardHost "dsh" -Title "DeepSeek Harness" `
+    -Description "启动 DSH Web，并将托盘切换到 DSH。" -Action "打开 →" `
+    -X 266 -Current ($currentHost -eq "dsh")
+
+  $footerHint = New-BcPickerLabel -Text "选择会替换当前托盘目标" -X 20 -Y 275 -Width 250 -Height 25 `
+    -Font $sectionFont -Color $colors.Muted
+  [void]$root.Controls.Add($footerHint)
+  $cancel = New-Object System.Windows.Forms.Button
+  $cancel.Text = "Esc 取消"
+  $cancel.Font = $sectionFont
+  $cancel.Location = New-Object System.Drawing.Point(420, 274)
+  $cancel.Size = New-Object System.Drawing.Size(78, 27)
+  $cancel.FlatStyle = [System.Windows.Forms.FlatStyle]::Flat
+  $cancel.FlatAppearance.BorderSize = 0
+  $cancel.FlatAppearance.MouseOverBackColor = $colors.Panel
+  $cancel.FlatAppearance.MouseDownBackColor = $colors.PanelSelected
+  $cancel.BackColor = $colors.Window
+  $cancel.ForeColor = $colors.Copper
+  $cancel.UseVisualStyleBackColor = $false
+  $cancel.UseCompatibleTextRendering = $false
+  $cancel.Cursor = [System.Windows.Forms.Cursors]::Hand
+  $cancel.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
+  $form.CancelButton = $cancel
+  [void]$root.Controls.Add($cancel)
+
+  $dragWindow = {
+    param($sender, $eventArgs)
+    if ($eventArgs.Button -eq [System.Windows.Forms.MouseButtons]::Left) {
+      [void][BeautiCodeHostPickerNative]::ReleaseCapture()
+      [void][BeautiCodeHostPickerNative]::SendMessage($form.Handle, 0xA1, [IntPtr]2, [IntPtr]::Zero)
+    }
+  }.GetNewClosure()
+  foreach ($dragControl in @($header, $mark, $brand, $eyebrow, $status)) {
+    $null = $dragControl.add_MouseDown($dragWindow)
+  }
+  $null = $form.add_KeyDown({
+    param($sender, $eventArgs)
+    if ($eventArgs.KeyCode -eq [System.Windows.Forms.Keys]::Escape) {
+      $form.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
+      $form.Close()
+      $eventArgs.Handled = $true
+    }
+  })
+  $form.Add_Shown({
+    Set-BcPickerRoundedRegion -Control $form -Radius 16
+    [void][BeautiCodeHostPickerNative]::ShowWindow($form.Handle, 5)
+    [void][BeautiCodeHostPickerNative]::SetForegroundWindow($form.Handle)
+    $form.Activate()
+  })
+  try {
+    $result = $form.ShowDialog()
+    if ($result -eq [System.Windows.Forms.DialogResult]::OK) {
+      return [string]$form.Tag
+    }
+    return $null
+  } finally {
+    if ($null -ne $brandImage) { $brandImage.Dispose() }
+    foreach ($font in $ownedFonts) { $font.Dispose() }
+    if ($null -ne $form.Icon) { $form.Icon.Dispose() }
+    $form.Dispose()
+  }
+}
+
+function Get-BcRunningHost {
+  foreach ($candidate in @("codex", "dsh")) {
+    $mutex = $null
+    try {
+      $mutex = [System.Threading.Mutex]::OpenExisting(
+        ("Local\beautiCode.Engine.Host.{0}.v1" -f $candidate)
+      )
+      return $candidate
+    } catch [System.Threading.WaitHandleCannotBeOpenedException] {
+      continue
+    } finally {
+      if ($null -ne $mutex) { $mutex.Dispose() }
+    }
+  }
+  return $null
+}
+
+function Test-BcTrayRunning {
+  $mutex = $null
+  try {
+    $mutex = [System.Threading.Mutex]::OpenExisting("Local\beautiCode.Engine.Tray.v1")
+    return $true
+  } catch [System.Threading.WaitHandleCannotBeOpenedException] {
+    return $false
+  } finally {
+    if ($null -ne $mutex) { $mutex.Dispose() }
+  }
+}
+
+function Send-BcTrayEvent {
+  param([string]$Name)
+  $event = $null
+  try {
+    $event = [System.Threading.EventWaitHandle]::OpenExisting($Name)
+    [void]$event.Set()
+    return $true
+  } catch [System.Threading.WaitHandleCannotBeOpenedException] {
+    return $false
+  } finally {
+    if ($null -ne $event) { $event.Dispose() }
+  }
+}
+
+function Show-BcSwitchError([string]$Message) {
+  Add-Type -AssemblyName System.Windows.Forms
+  if (-not ("BeautiCodeHostPickerNative" -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class BeautiCodeHostPickerNative {
+  [DllImport("user32.dll")]
+  public static extern bool ShowWindow(IntPtr hWnd, int command);
+  [DllImport("user32.dll")]
+  public static extern bool SetForegroundWindow(IntPtr hWnd);
+}
+'@
+  }
+
+  $owner = New-Object System.Windows.Forms.Form
+  $owner.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
+  $owner.FormBorderStyle = [System.Windows.Forms.FormBorderStyle]::FixedToolWindow
+  $owner.ShowInTaskbar = $false
+  $owner.TopMost = $true
+  $owner.Opacity = 0
+  try {
+    $owner.Show()
+    [void][BeautiCodeHostPickerNative]::ShowWindow($owner.Handle, 5)
+    [void][BeautiCodeHostPickerNative]::SetForegroundWindow($owner.Handle)
+    [System.Windows.Forms.MessageBox]::Show(
+      $owner,
+      $Message,
+      "beautiCode",
+      [System.Windows.Forms.MessageBoxButtons]::OK,
+      [System.Windows.Forms.MessageBoxIcon]::Warning
+    ) | Out-Null
+  } finally {
+    $owner.Close()
+    $owner.Dispose()
+  }
+}
+
+if ($DryRun -and $TargetHost -eq "prompt") {
+  throw "DryRun 必须显式指定 -TargetHost codex 或 dsh。"
+}
+
+$selected = if ($TargetHost -eq "prompt") {
+  Show-BcHostPicker
+} else {
+  $TargetHost
+}
+if (-not $selected) { return }
+
+$route = if ($selected -eq "dsh") {
+  [pscustomobject]@{
+    Host = "dsh"
+    Script = $dshLauncher
+    Arguments = @{ SkipBuild = $true }
+  }
+} else {
+  [pscustomobject]@{
+    Host = "codex"
+    Script = $codexLauncher
+    Arguments = @{}
+  }
+}
+if (-not (Test-Path -LiteralPath $route.Script -PathType Leaf)) {
+  Show-BcSwitchError "缺少 beautiCode 启动脚本：$($route.Script)"
+  return
+}
+
+if ($DryRun) {
+  $route | ConvertTo-Json -Depth 3
+  return
+}
+
+$runningHost = Get-BcRunningHost
+if ($runningHost -eq $route.Host) {
+  if ($route.Host -eq "dsh") {
+    try {
+      Start-Process -FilePath "http://127.0.0.1:3080" | Out-Null
+    } catch {
+      Show-BcSwitchError ("打开 DeepSeek Harness 网站失败：{0}" -f $_.Exception.Message)
+      return
+    }
+  }
+  [void](Send-BcTrayEvent -Name "Local\beautiCode.Engine.ShowPanel.v1")
+  return
+}
+if (Test-BcTrayRunning) {
+  if (-not $runningHost) {
+    Show-BcSwitchError "检测到旧版或未知的 beautiCode 托盘。请先从托盘菜单退出，再重新选择目标应用。"
+    return
+  }
+  if (-not (Send-BcTrayEvent -Name "Local\beautiCode.Engine.Shutdown.v1")) {
+    Show-BcSwitchError "无法通知当前 beautiCode 托盘退出。请手动退出后重试。"
+    return
+  }
+  $deadline = [DateTime]::UtcNow.AddSeconds(15)
+  while (Test-BcTrayRunning) {
+    if ([DateTime]::UtcNow -ge $deadline) {
+      Show-BcSwitchError "等待当前 beautiCode 托盘退出超时。请手动退出后重试。"
+      return
+    }
+    Start-Sleep -Milliseconds 100
+  }
+}
+
+try {
+  $routeArguments = $route.Arguments
+  & $route.Script @routeArguments
+} catch {
+  Show-BcSwitchError ("启动 {0} 失败：{1}" -f $route.Host, $_.Exception.Message)
+  exit 1
+}


### PR DESCRIPTION
## Summary
- Startup host picker chooses Codex or DeepSeek Harness
- `session-host` routes to the matching adapter via `--host`
- Per-host engine mutexes and polished picker UI aligned with tray style
- Dedicated `start-beauticode.ps1` / `start-beauticode-dsh.ps1` launchers

## Stack
Base: `feat/adapter-dsh`

## Test plan
- [x] session-host DSH mode test passes
- [ ] CI green
- [ ] Manual: picker launches Codex path and DSH path