### PR TITLE
bundle DeepSeek Harness runtime in the Windows installer

### DIFF
--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -1,4 +1,4 @@
-#pragma codepage "utf-8"
+#pragma codepage 65001
 
 #define MyAppName "beautiCode"
 #define MyAppPublisher "beautiCode"
@@ -53,9 +53,10 @@ Name: "autostart"; Description: "登录 Windows 后自动启动"; GroupDescripti
 Source: "{#StageDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode-engine.ps1"""; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"
-Name: "{autodesktop}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode-engine.ps1"""; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"; Tasks: desktopicon
+Name: "{autoprograms}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode.ps1"""; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"
+Name: "{autoprograms}\beautiCode · DeepSeek Harness"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode-dsh.ps1"" -SkipBuild"; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"
+Name: "{autodesktop}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode.ps1"""; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"; Tasks: desktopicon
 Name: "{userstartup}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode-engine.ps1"" -NoLaunchCodex"; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"; Tasks: autostart
 
 [Run]
-Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode-engine.ps1"""; WorkingDir: "{app}"; Description: "启动 beautiCode"; Flags: postinstall nowait skipifsilent
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode.ps1"""; WorkingDir: "{app}"; Description: "启动 beautiCode"; Flags: postinstall nowait skipifsilent

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -4,14 +4,16 @@
   Build a self-contained beautiCode Windows installer.
 
 .DESCRIPTION
-  Builds TypeScript, stages only runtime files, downloads and verifies the
-  official Node.js Windows x64 runtime, then compiles an Inno Setup installer.
+  Builds TypeScript, stages both host adapters, downloads and verifies the
+  official Node.js Windows x64 runtime, installs the integrity-pinned DSH into
+  a private bundle, then compiles an Inno Setup installer.
 #>
 [CmdletBinding()]
 param(
   [ValidatePattern("^\d+\.\d+\.\d+$")]
   [string]$NodeVersion = "24.18.0",
-  [string]$InnoCompiler = ""
+  [string]$InnoCompiler = "",
+  [string]$DshRuntimeCache = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -20,6 +22,11 @@ $ArtifactsRoot = Join-Path $RepoRoot "artifacts\windows"
 $StageRoot = Join-Path $ArtifactsRoot "stage"
 $CacheRoot = Join-Path $ArtifactsRoot "cache"
 $OutputRoot = Join-Path $ArtifactsRoot "installer"
+$DshCacheRoot = if ($DshRuntimeCache) {
+  [IO.Path]::GetFullPath($DshRuntimeCache)
+} else {
+  Join-Path $CacheRoot "dsh-runtime"
+}
 $InstallerScript = Join-Path $RepoRoot "installer\windows\beauticode.iss"
 $PinnedNodeVersion = "24.18.0"
 $PinnedNodeArchiveSha256 = "0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
@@ -33,6 +40,17 @@ function Assert-WorkspaceChild([string]$Path) {
   $target = [System.IO.Path]::GetFullPath($Path)
   if (-not $target.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)) {
     throw ("Refusing to modify a path outside the repository: {0}" -f $target)
+  }
+}
+
+function Get-Sha256Hex([string]$Path) {
+  $stream = [System.IO.File]::OpenRead($Path)
+  $sha256 = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    return ([System.BitConverter]::ToString($sha256.ComputeHash($stream))).Replace("-", "").ToLowerInvariant()
+  } finally {
+    $sha256.Dispose()
+    $stream.Dispose()
   }
 }
 
@@ -144,6 +162,12 @@ if (-not (Test-Path -LiteralPath $InstallerScript -PathType Leaf)) {
 
 $package = Get-Content -Raw -LiteralPath (Join-Path $RepoRoot "package.json") |
   ConvertFrom-Json
+$compatibility = Get-Content -Raw -LiteralPath (
+  Join-Path $RepoRoot "integrations\deepseek-harness\compatibility.json"
+) | ConvertFrom-Json
+if ($compatibility.schema -ne "beauticode.dsh-compatibility/v1") {
+  throw "DSH compatibility manifest is invalid."
+}
 $appVersion = [string]$package.version
 if ($appVersion -notmatch "^\d+\.\d+\.\d+$") {
   throw ("Installer requires a numeric three-part package version: {0}" -f $appVersion)
@@ -177,7 +201,7 @@ if (-not $checksumLine) {
   throw ("Official checksum was not found for {0}" -f $nodeArchiveName)
 }
 $expectedHash = ($checksumLine -split "\s+")[0].ToLowerInvariant()
-$actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $nodeArchive).Hash.ToLowerInvariant()
+$actualHash = Get-Sha256Hex $nodeArchive
 if ($actualHash -ne $expectedHash) {
   throw ("Node.js archive checksum mismatch: expected {0}, got {1}" -f $expectedHash, $actualHash)
 }
@@ -196,9 +220,12 @@ foreach ($relativeDir in @(
     "scripts",
     "packages\core",
     "packages\adapter-codex",
+    "packages\adapter-dsh",
+    "integrations\deepseek-harness",
     "node_modules\@beauticode\core",
     "runtime",
-    "licenses\node"
+    "licenses\node",
+    "licenses\dsh"
   )) {
   New-Item -ItemType Directory -Path (Join-Path $StageRoot $relativeDir) -Force | Out-Null
 }
@@ -208,9 +235,16 @@ foreach ($relativeFile in @(
     "apps\tray\start-tray.ps1",
     "assets\beauticode-icon-borderless.png",
     "scripts\codex-launch.ps1",
+    "scripts\start-beauticode.ps1",
     "scripts\start-beauticode-engine.ps1",
+    "scripts\start-beauticode-dsh.ps1",
+    "scripts\install-dsh-runtime.ps1",
     "packages\core\package.json",
     "packages\adapter-codex\package.json",
+    "packages\adapter-dsh\package.json",
+    "integrations\deepseek-harness\index.mjs",
+    "integrations\deepseek-harness\client.js",
+    "integrations\deepseek-harness\compatibility.json",
     "LICENSE",
     "NOTICE.md",
     "THIRD_PARTY_NOTICES.md"
@@ -229,6 +263,9 @@ Copy-RuntimeDirectory `
 Copy-RuntimeDirectory `
   (Join-Path $RepoRoot "packages\adapter-codex\dist") `
   (Join-Path $StageRoot "packages\adapter-codex\dist")
+Copy-RuntimeDirectory `
+  (Join-Path $RepoRoot "packages\adapter-dsh\dist") `
+  (Join-Path $StageRoot "packages\adapter-dsh\dist")
 Copy-Item -LiteralPath (Join-Path $RepoRoot "packages\core\package.json") `
   -Destination (Join-Path $StageRoot "node_modules\@beauticode\core\package.json") -Force
 Copy-RuntimeDirectory `
@@ -240,6 +277,18 @@ Copy-Item -LiteralPath (Join-Path $nodeDistribution "node.exe") `
 Copy-Item -LiteralPath (Join-Path $nodeDistribution "LICENSE") `
   -Destination (Join-Path $StageRoot "licenses\node\LICENSE") -Force
 
+& (Join-Path $RepoRoot "scripts\install-dsh-runtime.ps1") `
+  -InstallRoot $DshCacheRoot `
+  -CompatibilityFile (Join-Path $RepoRoot "integrations\deepseek-harness\compatibility.json") `
+  -NodeCommand (Join-Path $StageRoot "runtime\node.exe") `
+  -NpmCommand ((Get-Command npm.cmd -ErrorAction Stop).Source)
+Copy-RuntimeDirectory $DshCacheRoot (Join-Path $StageRoot "runtime\dsh")
+$dshLicense = Join-Path $StageRoot "runtime\dsh\versions\$($compatibility.supportedVersion)\node_modules\@deepseek-ai\dsh\LICENSE"
+if (-not (Test-Path -LiteralPath $dshLicense -PathType Leaf)) {
+  throw "Staged DSH license is missing."
+}
+Copy-Item -LiteralPath $dshLicense -Destination (Join-Path $StageRoot "licenses\dsh\LICENSE") -Force
+
 New-InstallerIcon `
   (Join-Path $RepoRoot "assets\beauticode-icon-borderless.png") `
   (Join-Path $StageRoot "beauticode.ico")
@@ -250,6 +299,8 @@ $manifest = [ordered]@{
   schema = "beauticode.release/v1"
   appVersion = $appVersion
   nodeVersion = $NodeVersion
+  dshVersion = [string]$compatibility.supportedVersion
+  dshBridgeProtocol = [int]$compatibility.bridgeProtocol
   platform = "win-x64"
   commit = $commit
   dirty = ($trackedChanges.Count -gt 0)
@@ -271,6 +322,19 @@ $adapterProbe = & $stagedNode --input-type=module -e `
 if ($LASTEXITCODE -ne 0 -or $adapterProbe -ne "function") {
   throw ("Staged adapter import failed: {0}" -f $adapterProbe)
 }
+$dshAdapterUrl = ([System.Uri](Join-Path $StageRoot "packages\adapter-dsh\dist\index.js")).AbsoluteUri
+$dshAdapterProbe = & $stagedNode --input-type=module -e `
+  "const m=await import(process.argv[1]); console.log(typeof m.DshSession);" `
+  $dshAdapterUrl
+if ($LASTEXITCODE -ne 0 -or $dshAdapterProbe -ne "function") {
+  throw ("Staged DSH adapter import failed: {0}" -f $dshAdapterProbe)
+}
+$dshManifest = Get-Content -Raw -LiteralPath (Join-Path $StageRoot "runtime\dsh\current.json") | ConvertFrom-Json
+$dshCli = Join-Path (Join-Path $StageRoot "runtime\dsh") ([string]$dshManifest.cli)
+$stagedDshVersion = (& $stagedNode $dshCli --version).Trim()
+if ($LASTEXITCODE -ne 0 -or $stagedDshVersion -ne [string]$compatibility.supportedVersion) {
+  throw ("Staged DSH version mismatch: expected {0}, got {1}" -f $compatibility.supportedVersion, $stagedDshVersion)
+}
 
 $iscc = Resolve-InnoCompiler $InnoCompiler
 & $iscc `
@@ -289,8 +353,8 @@ if (-not $installer) {
   throw "Inno Setup completed without producing an installer."
 }
 
-$installerHash = Get-FileHash -Algorithm SHA256 -LiteralPath $installer.FullName
+$installerHash = Get-Sha256Hex $installer.FullName
 Write-Host ""
 Write-Host "Windows installer created:"
 Write-Host ("  {0}" -f $installer.FullName)
-Write-Host ("  SHA256 {0}" -f $installerHash.Hash)
+Write-Host ("  SHA256 {0}" -f $installerHash.ToUpperInvariant())

--- a/scripts/install-dsh-runtime.ps1
+++ b/scripts/install-dsh-runtime.ps1
@@ -1,0 +1,221 @@
+﻿#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Install the supported DeepSeek Harness into a beautiCode-owned directory.
+
+.DESCRIPTION
+  Uses an exact package version, verifies npm's recorded SHA-512 integrity and
+  the live CLI version, then atomically publishes a versioned runtime. It never
+  performs a global npm installation.
+#>
+[CmdletBinding()]
+param(
+  [string]$InstallRoot = "",
+  [string]$CompatibilityFile = "",
+  [string]$PackageVersion = "",
+  [string]$PackageIntegrity = "",
+  [string]$NodeCommand = "",
+  [string]$NpmCommand = "",
+  [switch]$Force,
+  [switch]$Offline,
+  [switch]$PassThru
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not $CompatibilityFile) {
+  $CompatibilityFile = Join-Path $RepoRoot "integrations\deepseek-harness\compatibility.json"
+}
+if (-not (Test-Path -LiteralPath $CompatibilityFile -PathType Leaf)) {
+  throw "缺少 DSH 兼容性清单：$CompatibilityFile"
+}
+$compatibility = Get-Content -Raw -LiteralPath $CompatibilityFile | ConvertFrom-Json
+if ($compatibility.schema -ne "beauticode.dsh-compatibility/v1") {
+  throw "DSH 兼容性清单版本无效。"
+}
+if (-not $PackageVersion) { $PackageVersion = [string]$compatibility.supportedVersion }
+if (-not $PackageIntegrity) { $PackageIntegrity = [string]$compatibility.integrity }
+if ($PackageVersion -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+  throw "DSH 版本格式无效：$PackageVersion"
+}
+if ($PackageIntegrity -notmatch '^sha512-[A-Za-z0-9+/]+={0,2}$') {
+  throw "DSH SHA-512 integrity 无效。"
+}
+
+if (-not $InstallRoot) {
+  $base = if ($env:LOCALAPPDATA) {
+    Join-Path $env:LOCALAPPDATA "beautiCode"
+  } else {
+    Join-Path ([IO.Path]::GetTempPath()) "beautiCode"
+  }
+  $InstallRoot = Join-Path $base "dsh-runtime"
+}
+$InstallRoot = [IO.Path]::GetFullPath($InstallRoot)
+$VersionsRoot = Join-Path $InstallRoot "versions"
+$TargetRoot = Join-Path $VersionsRoot $PackageVersion
+$CurrentManifest = Join-Path $InstallRoot "current.json"
+$CliRelativePath = "node_modules\@deepseek-ai\dsh\lib\bin.js"
+
+function Resolve-BcCommandPath {
+  param([string]$Requested, [string]$Fallback)
+  if ($Requested) {
+    if (-not (Test-Path -LiteralPath $Requested -PathType Leaf)) {
+      throw "命令不存在：$Requested"
+    }
+    return (Resolve-Path -LiteralPath $Requested).Path
+  }
+  $command = Get-Command $Fallback -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $command) { throw "未找到 $Fallback。" }
+  return $command.Source
+}
+
+function Get-BcInstalledDshVersion {
+  param([string]$RuntimeRoot, [string]$NodePath, [switch]$ThrowOnError)
+  $cli = Join-Path $RuntimeRoot $CliRelativePath
+  if (-not (Test-Path -LiteralPath $cli -PathType Leaf)) { return $null }
+  try {
+    $output = @(& $NodePath $cli --version 2>&1)
+    $exitCode = $LASTEXITCODE
+    $version = ([string]($output | Select-Object -First 1)).Trim()
+    if ($exitCode -eq 0 -and $version -match '^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$') {
+      return $version
+    }
+    $detail = (($output | ForEach-Object { [string]$_ }) -join " ").Trim()
+    if (-not $detail) { $detail = "无输出" }
+    if ($ThrowOnError) {
+      throw "DSH CLI 无法读取版本（退出码 $exitCode）：$detail"
+    }
+    return $null
+  } catch {
+    if ($ThrowOnError) { throw $_ }
+    return $null
+  }
+}
+
+function Get-BcLockIntegrity {
+  param(
+    [Parameter(Mandatory = $true)][string]$LockPath,
+    [Parameter(Mandatory = $true)][string]$NodePath
+  )
+  $script = @"
+const fs = require('node:fs');
+const lock = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+const entry = lock.packages?.['node_modules/@deepseek-ai/dsh'];
+if (!entry?.integrity) process.exit(2);
+process.stdout.write(entry.integrity);
+"@
+  $integrity = (& $NodePath -e $script $LockPath 2>$null | Out-String).Trim()
+  if ($LASTEXITCODE -ne 0) { return $null }
+  $integrity
+}
+
+function Write-BcCurrentManifest {
+  param([string]$NodePath)
+  $relativeRoot = Join-Path "versions" $PackageVersion
+  $relativeCli = Join-Path $relativeRoot $CliRelativePath
+  $manifest = [ordered]@{
+    schema = "beauticode.dsh-runtime/v1"
+    package = "@deepseek-ai/dsh"
+    version = $PackageVersion
+    integrity = $PackageIntegrity
+    runtimeRoot = $relativeRoot
+    cli = $relativeCli
+    installedAtUtc = [DateTime]::UtcNow.ToString("o")
+  }
+  [IO.Directory]::CreateDirectory($InstallRoot) | Out-Null
+  [IO.File]::WriteAllText(
+    $CurrentManifest,
+    ($manifest | ConvertTo-Json),
+    (New-Object Text.UTF8Encoding($false))
+  )
+  return [pscustomobject]@{
+    Version = $PackageVersion
+    Integrity = $PackageIntegrity
+    Root = $TargetRoot
+    Cli = Join-Path $InstallRoot $relativeCli
+    Node = $NodePath
+    Installed = $true
+  }
+}
+
+$nodePath = Resolve-BcCommandPath -Requested $NodeCommand -Fallback "node.exe"
+$existingVersion = Get-BcInstalledDshVersion -RuntimeRoot $TargetRoot -NodePath $nodePath
+if (-not $Force -and $existingVersion -eq $PackageVersion) {
+  $result = Write-BcCurrentManifest -NodePath $nodePath
+  $result.Installed = $false
+  if ($PassThru) { $result }
+  return
+}
+
+$npmPath = Resolve-BcCommandPath -Requested $NpmCommand -Fallback "npm.cmd"
+[IO.Directory]::CreateDirectory($VersionsRoot) | Out-Null
+$stagingRoot = Join-Path $InstallRoot (".staging-{0}-{1}" -f $PID, [guid]::NewGuid().ToString("N"))
+$published = $false
+try {
+  [IO.Directory]::CreateDirectory($stagingRoot) | Out-Null
+  $package = [ordered]@{
+    name = "beauticode-dsh-runtime"
+    version = "1.0.0"
+    private = $true
+    dependencies = [ordered]@{ "@deepseek-ai/dsh" = $PackageVersion }
+  }
+  [IO.File]::WriteAllText(
+    (Join-Path $stagingRoot "package.json"),
+    ($package | ConvertTo-Json -Depth 4),
+    (New-Object Text.UTF8Encoding($false))
+  )
+  $npmArguments = @(
+    "install",
+    "--prefix", $stagingRoot,
+    "--ignore-scripts",
+    "--omit=dev",
+    "--no-audit",
+    "--no-fund",
+    "--save-exact"
+  )
+  if ($Offline) { $npmArguments += "--offline" }
+  & $npmPath @npmArguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "DSH 私有运行时安装失败（npm 退出码 $LASTEXITCODE）。"
+  }
+
+  $packageJson = Get-Content -Raw -LiteralPath (
+    Join-Path $stagingRoot "node_modules\@deepseek-ai\dsh\package.json"
+  ) | ConvertFrom-Json
+  if ([string]$packageJson.version -ne $PackageVersion) {
+    throw "DSH 安装版本不匹配：期望 $PackageVersion，实际 $($packageJson.version)。"
+  }
+  $lockIntegrity = Get-BcLockIntegrity `
+    -LockPath (Join-Path $stagingRoot "package-lock.json") `
+    -NodePath $nodePath
+  if ($lockIntegrity -ne $PackageIntegrity) {
+    throw "DSH npm integrity 校验失败。"
+  }
+  $installedVersion = Get-BcInstalledDshVersion `
+    -RuntimeRoot $stagingRoot `
+    -NodePath $nodePath `
+    -ThrowOnError
+  if ($installedVersion -ne $PackageVersion) {
+    throw "DSH CLI 版本校验失败：期望 $PackageVersion，实际 $installedVersion。"
+  }
+
+  if (Test-Path -LiteralPath $TargetRoot) {
+    $quarantine = Join-Path $VersionsRoot (
+      "{0}.invalid-{1}" -f $PackageVersion, (Get-Date -Format "yyyyMMddHHmmss")
+    )
+    Move-Item -LiteralPath $TargetRoot -Destination $quarantine
+  }
+  Move-Item -LiteralPath $stagingRoot -Destination $TargetRoot
+  $published = $true
+  $result = Write-BcCurrentManifest -NodePath $nodePath
+  Write-Host ("DeepSeek Harness {0} 已安装到 beautiCode 私有运行时。" -f $PackageVersion)
+  if ($PassThru) { $result }
+} finally {
+  if (-not $published -and (Test-Path -LiteralPath $stagingRoot)) {
+    $safeRoot = $InstallRoot.TrimEnd("\") + "\"
+    $resolvedStaging = [IO.Path]::GetFullPath($stagingRoot)
+    if ($resolvedStaging.StartsWith($safeRoot, [StringComparison]::OrdinalIgnoreCase)) {
+      Remove-Item -LiteralPath $resolvedStaging -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Stage adapter-dsh, bridge plugin, and integrity-pinned DSH runtime
- Point Start Menu/desktop shortcuts at the host-picker launcher
- Add private DSH runtime install helper used by the package builder

## Stack
Base: `feat/host-picker-tray`

## Test plan
- [ ] `npm run installer:windows` produces a clean manifest (`dirty=false`)
- [ ] Staged DSH bridge hashes match source
- [ ] CI green