### PR TITLE
release v0.1.5 with DeepSeek Harness multi-host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ beautiCode 可以让你：
 > 不是逃离工作，而是给漫长的工作过程，留一点属于自己的空间。
 <img width="1920" height="1240" alt="QQ20260729-212506-HD" src="https://github.com/user-attachments/assets/ca0ef07f-2aec-46b0-b996-1db9913efa6d" />
 
-### v0.1.4 安装包
+### v0.1.5 安装包
 
-想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.4)。
+想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v0.1.5)。
 安装包自带运行时，不需要另外安装 Node.js 或 npm；使用前请先安装 Codex Desktop。
+安装包同时内置 DeepSeek Harness 运行时；启动时可选 Codex 或 DeepSeek Harness。
 
 
 
@@ -163,7 +164,7 @@ Ctrl + Shift + Space
 运行：
 
 ```text
-beautiCode-Setup-0.1.4-win-x64.exe
+beautiCode-Setup-0.1.5-win-x64.exe
 ```
 
 安装包自带 Node.js 运行时。使用者不需要安装 Node.js、npm，也不需要保留

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "name": "beauticode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beauticode",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beauticode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "description": "Local image/video backgrounds for supported coding hosts. Unofficial.",


### PR DESCRIPTION
## Summary
- Bump app/installer version to **0.1.5**
- README download link and installer filename point at the DSH-capable package
- Ships beside existing public v0.1.4 (Codex-only) without replacing it

## Stack
Base: `feat/dsh-installer` (full DSH stack)

## Test plan
- [x] package.json / lock = 0.1.5
- [ ] Clean installer build + GitHub Release `v0.1.5` asset upload
- [ ] CI green