### PR TITLE
refactor: ponytail audit — cut dead paths and legacy forms

### DIFF
--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -916,13 +916,9 @@ $L = @{
   RunningTipDsh  = (U "6258 76D8 5DF2 542F 52A8 3002 8BF7 5148 6253 5F00 0020 0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7F51 9875 3002") # 托盘已启动。请先打开 DeepSeek Harness 网页。
   HostCodex      = "Codex Desktop"
   HostDsh        = "DeepSeek Harness"
-  DshPhaseOne    = (U "0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7B2C 4E00 9636 6BB5 4EC5 652F 6301 56FE 7247 80CC 666F 3001 6E05 9664 548C 91CD 65B0 5E94 7528 3002") # DeepSeek Harness 第一阶段仅支持图片背景、清除和重新应用。
-  FailedSuffix   = (U "5931 8D25")                                         # 失败
   MediaImage     = (U "56FE 7247")                                         # 图片
   MediaVideo     = (U "89C6 9891")                                         # 视频
-  MediaClear     = (U "65E0")                                               # 无
   NoBackground   = (U "6682 65E0 80CC 666F")                               # 暂无背景
-  Sessions       = (U "4F1A 8BDD")                                         # 会话
   HotkeyFail     = (U "5168 5C40 5FEB 6377 952E 6CE8 518C 5931 8D25 FF0C 4ECD 53EF 7528 6258 76D8 83DC 5355 5207 6362 6478 9C7C 6A21 5F0F 3002") # 全局快捷键注册失败，仍可用托盘菜单切换摸鱼模式。
 }
 

--- a/integrations/deepseek-harness/index.mjs
+++ b/integrations/deepseek-harness/index.mjs
@@ -9,24 +9,7 @@ export const bridgeProtocol = 4;
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const TOKEN_PATTERN = /^[a-f0-9]{64}$/;
-const REVISION_PATTERN = /^[a-f0-9]{64}$/;
 const MAX_BODY_BYTES = 64 * 1024;
-
-async function readBridgeIdentity() {
-  try {
-    const manifest = JSON.parse(
-      await fs.readFile(path.join(here, "bridge-manifest.json"), "utf8"),
-    );
-    if (
-      manifest.schema === "beauticode.dsh-bridge/v1" &&
-      manifest.protocol === bridgeProtocol &&
-      REVISION_PATTERN.test(manifest.revision)
-    ) {
-      return { protocol: bridgeProtocol, revision: manifest.revision };
-    }
-  } catch {}
-  return { protocol: bridgeProtocol, revision: "source" };
-}
 
 /**
  * Token file must be explicit too: plugin `config.tokenFile` or the shared
@@ -218,12 +201,15 @@ export function apply(ctx, config = {}) {
             res.writeHead(405).end();
             return;
           }
-          const identity = await readBridgeIdentity();
           if (req.method === "HEAD") {
             res.writeHead(200, { "cache-control": "no-store" }).end();
             return;
           }
-          sendJson(res, 200, { ok: true, ...identity });
+          sendJson(res, 200, {
+            ok: true,
+            protocol: bridgeProtocol,
+            revision: "source",
+          });
         },
       }),
       ctx.webServer.register({

--- a/packages/adapter-codex/src/index.ts
+++ b/packages/adapter-codex/src/index.ts
@@ -34,11 +34,6 @@ export {
 } from "./payload.js";
 
 export {
-  MemoryHostApplier,
-  type MemoryHostOptions,
-} from "./memory-host.js";
-
-export {
   CodexHostApplier,
   type CodexHostApplierOptions,
   type ConnectedTarget,

--- a/packages/adapter-codex/test/adapter.test.js
+++ b/packages/adapter-codex/test/adapter.test.js
@@ -9,7 +9,6 @@ import {
   buildInjectionExpression,
   CodexHostApplier,
   isCandidatePageTarget,
-  MemoryHostApplier,
   readBoundedJson,
   runApplyOnce,
   runWatch,
@@ -21,6 +20,7 @@ import {
   getCodexLaunchGuidance,
   BeautiSession,
 } from "../dist/index.js";
+import { MemoryHostApplier } from "./helpers/memory-host.js";
 import { startMockCdp } from "./mock-cdp.js";
 import http from "node:http";
 

--- a/packages/adapter-codex/test/helpers/memory-host.js
+++ b/packages/adapter-codex/test/helpers/memory-host.js
@@ -1,37 +1,19 @@
-import type {
-  HostApplyPayload,
-  HostApplier,
-  VerifyExpectation,
-  VerifyResult,
-} from "@beauticode/core";
-
-export interface MemoryHostOptions {
-  verifyStatus?: VerifyResult["status"];
-  verifyReason?: string;
-}
-
 /**
  * In-process host applier for unit tests — records payloads and exposes the
  * last generation for assertions. Not used against a real Codex window.
  */
-export class MemoryHostApplier implements HostApplier {
-  payloads: HostApplyPayload[] = [];
-  verifyStatus: VerifyResult["status"];
-  verifyReason: string;
-
-  constructor(opts: MemoryHostOptions = {}) {
+export class MemoryHostApplier {
+  constructor(opts = {}) {
+    this.payloads = [];
     this.verifyStatus = opts.verifyStatus ?? "pass";
     this.verifyReason = opts.verifyReason ?? "memory host";
   }
 
-  async apply(payload: HostApplyPayload): Promise<void> {
+  async apply(payload) {
     this.payloads.push(payload);
   }
 
-  async verify(
-    expected: VerifyExpectation,
-    _opts: { deadlineMs: number },
-  ): Promise<VerifyResult> {
+  async verify(expected, _opts) {
     const last = this.payloads[this.payloads.length - 1];
     if (!last) {
       return { status: "fail", reason: "no payload applied" };

--- a/packages/core/src/media-server.ts
+++ b/packages/core/src/media-server.ts
@@ -551,29 +551,6 @@ export async function createMediaServer(
   };
 }
 
-function isAssetHandle(value: unknown): value is MediaAssetHandle {
-  if (!value || typeof value !== "object") return false;
-  const v = value as Record<string, unknown>;
-  return (
-    (v.kind === "image" || v.kind === "video") &&
-    typeof v.token === "string" &&
-    typeof v.srcUrl === "string" &&
-    !("image" in v && typeof v.image === "object") &&
-    !("video" in v && typeof v.video === "object")
-  );
-}
-
-function isPairCommit(
-  value: unknown,
-): value is {
-  image?: MediaAssetHandle | null;
-  video?: MediaAssetHandle | null;
-} {
-  if (!value || typeof value !== "object") return false;
-  // Pair shape is chosen when image/video keys are present (even if null).
-  return "image" in value || "video" in value;
-}
-
 /**
  * Controller that can hold poster image + video assets on one hub.
  */
@@ -610,30 +587,13 @@ export class MediaServerController {
    * Promote staged image/video handles; close assets that are no longer needed.
    */
   async commit(
-    next:
-      | {
-          image?: MediaAssetHandle | null;
-          video?: MediaAssetHandle | null;
-        }
-      | MediaAssetHandle
-      | null,
+    next: {
+      image?: MediaAssetHandle | null;
+      video?: MediaAssetHandle | null;
+    } | null,
   ): Promise<void> {
-    let nextImage: MediaAssetHandle | null = null;
-    let nextVideo: MediaAssetHandle | null = null;
-
-    if (next == null) {
-      nextImage = null;
-      nextVideo = null;
-    } else if (isPairCommit(next)) {
-      nextImage = next.image ?? null;
-      nextVideo = next.video ?? null;
-    } else if (isAssetHandle(next)) {
-      // Legacy single-handle commit.
-      if (next.kind === "image") nextImage = next;
-      else nextVideo = next;
-    } else {
-      throw new Error("Invalid media commit payload.");
-    }
+    const nextImage = next?.image ?? null;
+    const nextVideo = next?.video ?? null;
 
     const prevImage = this.#image;
     const prevVideo = this.#video;

--- a/scripts/beauticode.mjs
+++ b/scripts/beauticode.mjs
@@ -351,30 +351,14 @@ async function main() {
       finish(1);
       return;
     }
-    // Dream-Skin style: video-only is enough. Optional poster as 2nd arg.
-    // Legacy form `apply-video <image> <video.mp4>` still works when the first
-    // arg is an image and the second is .mp4.
+    // <video.mp4> [poster]; video-only is enough.
     const aPath = path.resolve(a);
-    const bPath = b ? path.resolve(b) : null;
     const aIsMp4 = path.extname(aPath).toLowerCase() === ".mp4";
-    const bIsMp4 = bPath
-      ? path.extname(bPath).toLowerCase() === ".mp4"
-      : false;
-    if (aIsMp4 && !bIsMp4) {
+    if (aIsMp4) {
       input = { type: "video", videoPath: aPath };
-      if (bPath) input.imagePath = bPath;
-    } else if (bIsMp4) {
-      input = {
-        type: "video",
-        imagePath: aPath,
-        videoPath: bPath,
-      };
-    } else if (aIsMp4) {
-      input = { type: "video", videoPath: aPath };
+      if (b) input.imagePath = path.resolve(b);
     } else {
-      console.error(
-        "apply-video 需要 <video.mp4> [poster]（或旧格式 <poster> <video.mp4>）。",
-      );
+      console.error("apply-video 需要 <video.mp4> [poster]。");
       finish(1);
       return;
     }


### PR DESCRIPTION
Drop dead bridge-manifest identity, legacy media-server single-handle commit, CLI apply-video legacy arg form, unreferenced tray labels; move test-only MemoryHostApplier out of the production index. PR 7/7.