### PR TITLE
refactor: require an explicit data root everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,7 @@ dsh web
 退出托盘不会结束 DeepSeek Harness，避免打断正在进行的工作。
 
 当前安装包尚未进行商业代码签名，Windows 可能显示 SmartScreen 提示。
-用户导入的图片、视频和已保存主题位于
-`%LOCALAPPDATA%\beautiCode`，卸载程序默认保留这些数据。
+用户导入的图片、视频和已保存主题位于数据根目录（托盘默认 `%LOCALAPPDATA%\beautiCode`，由 `BEAUTICODE_DATA_ROOT` 或 `--data-root` 显式指定），卸载程序默认保留这些数据。
 
 ### 从源码运行
 

--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -341,6 +341,17 @@ function ConvertTo-PsLiteral([string]$Value) {
   return "'" + ($Value -replace "'", "''") + "'"
 }
 
+# The data root is explicit: the tray (as launcher) always picks one and hands
+# it to the engine — core never guesses a default. Default follows the Windows
+# install convention; DSH/Codex control must share the same root.
+if (-not $DataRoot) {
+  $DataRoot = if ($env:LOCALAPPDATA) {
+    Join-Path $env:LOCALAPPDATA "beautiCode"
+  } else {
+    Join-Path ([System.IO.Path]::GetTempPath()) "beautiCode"
+  }
+}
+
 $nodeInvocationParts = @(
   (ConvertTo-PsLiteral $Node),
   (ConvertTo-PsLiteral $HostScript),

--- a/docs/security-boundaries.md
+++ b/docs/security-boundaries.md
@@ -30,7 +30,7 @@
 
 | Zone | Trust | Notes |
 |---|---|---|
-| beautiCode data root | Owned | `%LOCALAPPDATA%\beautiCode` (Windows default) |
+| beautiCode data root | Owned | Explicit only: `BEAUTICODE_DATA_ROOT` or `--data-root`. No hidden default (tray defaults to `%LOCALAPPDATA%\beautiCode` and passes it explicitly) |
 | Imported user media | Untrusted input | Validated then copied into data root |
 | Loopback media server | Guarded | Token + origin + re-stat + identity hash |
 | Host renderer | Untrusted peer | May navigate, hide, or drop nodes; generation guards required |

--- a/docs/windows-installer.md
+++ b/docs/windows-installer.md
@@ -8,16 +8,18 @@
 %LOCALAPPDATA%\Programs\beautiCode
 ```
 
-The package includes the compiled beautiCode runtime, a pinned Node.js x64
-runtime, and a compatible DeepSeek Harness. The target machine does not need
-Node.js, npm, TypeScript, DSH, or a source checkout. Codex Desktop is optional
-and remains a separate prerequisite if you choose that host.
+The package includes the compiled beautiCode runtime and a pinned Node.js x64
+runtime. The target machine does not need Node.js, npm, TypeScript, or a source
+checkout. DeepSeek Harness is **not** bundled — install the
+`@beauticode/dsh-plugin` into your DSH profile and run `dsh web` yourself.
+Codex Desktop is optional and remains a separate prerequisite if you choose
+that host.
 
 The installer creates a Start menu shortcut. Desktop and login-start shortcuts
 are optional installer tasks. Uninstall removes program files and shortcuts but
-preserves `%LOCALAPPDATA%\beautiCode`, which contains user media and themes.
-Quit the beautiCode tray before an upgrade or uninstall so the bundled runtime
-is not in use.
+preserves the data root (tray default `%LOCALAPPDATA%\beautiCode`), which
+contains user media and themes. Quit the beautiCode tray before an upgrade or
+uninstall so the bundled runtime is not in use.
 
 ## Build
 
@@ -56,18 +58,19 @@ The locally installed Inno Setup 6.7.3 compiler identifies itself as
 non-commercial-use-only. Review or replace that build-tool license before using
 this pipeline for a commercial distribution.
 
-The installer targets x64-compatible Windows. DeepSeek Harness is bundled and
-is the recommended host. The installer does not patch Codex Desktop; that path
-still depends on Codex exposing a healthy loopback CDP endpoint.
+The installer targets x64-compatible Windows. DeepSeek Harness is the
+recommended host and is user-managed (plugin + `dsh web`). The installer does
+not patch Codex Desktop; that path still depends on Codex exposing a healthy
+loopback CDP endpoint.
 
 The current bundled Node.js runtime requires 64-bit Windows 10 version 1809
-(build 17763) or newer. If you use Codex and it was already running without
-loopback CDP, use the tray's “Apply or re-apply” action; it will restart Codex
-only after the normal confirmation prompt.
+(build 17763) or newer. beautiCode never starts or restarts a host: if Codex is
+running without loopback CDP, open it with `--remote-debugging-port=9335
+--remote-debugging-address=127.0.0.1` (the tray's “Apply or re-apply” will ask
+you to do so).
 
 Startup diagnostics are written to:
 
 ```text
-%LOCALAPPDATA%\beautiCode\logs\engine-launcher.log
 %LOCALAPPDATA%\beautiCode\logs\tray.log
 ```

--- a/integrations/deepseek-harness/index.mjs
+++ b/integrations/deepseek-harness/index.mjs
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,13 +28,16 @@ async function readBridgeIdentity() {
   return { protocol: bridgeProtocol, revision: "source" };
 }
 
-function defaultTokenFile() {
-  const base =
-    process.env.BEAUTICODE_DATA_ROOT ||
-    (process.env.LOCALAPPDATA
-      ? path.join(process.env.LOCALAPPDATA, "beautiCode")
-      : path.join(os.homedir(), ".beauticode"));
-  return path.join(base, "dsh-bridge.token");
+/**
+ * Token file must be explicit too: plugin `config.tokenFile` or the shared
+ * `BEAUTICODE_DATA_ROOT` environment variable. No LOCALAPPDATA guess — the
+ * control side and the plugin must agree on one data root.
+ */
+function resolveTokenFile(config) {
+  if (config.tokenFile) return path.resolve(config.tokenFile);
+  const base = process.env.BEAUTICODE_DATA_ROOT;
+  if (base) return path.join(base, "dsh-bridge.token");
+  return null;
 }
 
 function sendJson(res, status, body) {
@@ -178,11 +180,20 @@ function publicStatus(current, modes, clients, clientStates) {
 }
 
 export function apply(ctx, config = {}) {
-  const tokenFile = path.resolve(config.tokenFile || defaultTokenFile());
+  const tokenFile = resolveTokenFile(config);
   const clients = new Map();
   const clientStates = new Map();
   let current = null;
   const modes = { fish: false, muted: true, tone: "dark" };
+
+  const requireTokenFile = (res) => {
+    if (tokenFile) return true;
+    sendJson(res, 503, {
+      ok: false,
+      error: "未配置数据根。请设置 BEAUTICODE_DATA_ROOT 或插件 config.tokenFile。",
+    });
+    return false;
+  };
 
   const broadcast = (payload) => {
     const frame = `data: ${JSON.stringify(payload)}\n\n`;
@@ -275,6 +286,7 @@ export function apply(ctx, config = {}) {
             res.writeHead(405).end();
             return;
           }
+          if (!requireTokenFile(res)) return;
           if (!(await authorized(req, tokenFile))) {
             sendJson(res, 401, { ok: false, error: "未授权的请求。" });
             return;
@@ -306,6 +318,7 @@ export function apply(ctx, config = {}) {
             res.writeHead(405).end();
             return;
           }
+          if (!requireTokenFile(res)) return;
           if (!(await authorized(req, tokenFile))) {
             sendJson(res, 401, { ok: false, error: "未授权的请求。" });
             return;
@@ -338,6 +351,7 @@ export function apply(ctx, config = {}) {
             res.writeHead(405).end();
             return;
           }
+          if (!requireTokenFile(res)) return;
           if (!(await authorized(req, tokenFile))) {
             sendJson(res, 401, { ok: false, error: "未授权的请求。" });
             return;

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import crypto from "node:crypto";
 import {
   ACTIVE_DIR_NAME,
@@ -15,16 +14,20 @@ import {
 const DATA_ROOT_MARKER_NAME = ".beauticode-root.json";
 const DATA_ROOT_SCHEMA = "beauticode.data-root/v1";
 
+/**
+ * The data root is always explicit: `BEAUTICODE_DATA_ROOT` or `--data-root`.
+ * There is no hidden default and no LOCALAPPDATA guess — two processes talking
+ * to the same store must agree on one root, so an implicit second copy would
+ * silently split them (the DSH-history bug class this replaces).
+ */
 export function defaultDataRoot(): string {
-  if (process.platform === "win32") {
-    const base = process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
-    return path.join(base, "beautiCode");
+  const value = process.env.BEAUTICODE_DATA_ROOT;
+  if (!value) {
+    throw new Error(
+      "未设置 BEAUTICODE_DATA_ROOT。beautiCode 数据根必须显式指定（环境变量 BEAUTICODE_DATA_ROOT 或 --data-root）。",
+    );
   }
-  if (process.platform === "darwin") {
-    return path.join(os.homedir(), "Library", "Application Support", "beautiCode");
-  }
-  const xdg = process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share");
-  return path.join(xdg, "beautiCode");
+  return path.resolve(value);
 }
 
 export interface DataPaths {
@@ -91,7 +94,6 @@ export async function ensureDataLayout(paths: DataPaths): Promise<void> {
       entry === SAVED_DIR_NAME ||
       entry === RUNTIME_MEDIA_DIR_NAME ||
       entry === "logs" ||
-      entry === "engine-launcher.log" ||
       entry === "injector.lock" ||
       entry === "store.lock" ||
       entry === ".beauticode-commit.json" ||

--- a/packages/core/test/background-store.test.js
+++ b/packages/core/test/background-store.test.js
@@ -593,9 +593,8 @@ test("data root ownership adopts a valid legacy active manifest", async () => {
   await fs.rm(root, { recursive: true, force: true });
 });
 
-test("data root tolerates launcher logs created before the ownership marker", async () => {
+test("data root tolerates tray logs created before the ownership marker", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "bc-root-log-"));
-  await fs.writeFile(path.join(root, "engine-launcher.log"), "old launcher\n", "utf8");
   await fs.mkdir(path.join(root, "logs"));
   await fs.writeFile(path.join(root, "logs", "tray.log"), "old tray\n", "utf8");
 

--- a/scripts/beauticode.mjs
+++ b/scripts/beauticode.mjs
@@ -37,6 +37,12 @@ function finish(code) {
   process.exitCode = code;
 }
 
+function currentDataRootLabel() {
+  return process.env.BEAUTICODE_DATA_ROOT
+    ? path.resolve(process.env.BEAUTICODE_DATA_ROOT)
+    : "(必填：BEAUTICODE_DATA_ROOT 或 --data-root)";
+}
+
 function printUsage() {
   console.log(`beautiCode CLI
 
@@ -64,12 +70,12 @@ Windows tray:
 Options:
   --port <n>           Loopback CDP port
   --discover           Auto-pick a healthy loopback Codex CDP port
-  --data-root <path>   Override data directory (default: ${defaultDataRoot()})
+  --data-root <path>   Data directory (required; or BEAUTICODE_DATA_ROOT)
   --verify-ms <n>      Live verify deadline in ms (default 30000)
   --url-prefix <s>     Prefer page targets with this URL prefix (default app://)
   --allow-http         Allow http://127.0.0.1 test pages (disables app: requirement)
 
-Data root: ${defaultDataRoot()}
+Data root: ${currentDataRootLabel()}
 `);
 }
 
@@ -203,7 +209,9 @@ async function main() {
 
   const [cmd, a, b] = parsed.positionals;
   const { flags } = parsed;
-  const dataRoot = flags.dataRoot ?? defaultDataRoot();
+  // Data root is lazy: discovery/probe commands never touch the store and must
+  // work without BEAUTICODE_DATA_ROOT. Store-touching commands resolve it now.
+  const requireDataRoot = () => flags.dataRoot ?? defaultDataRoot();
   const adapter = await import(adapterEntry);
 
   if (cmd === "how-to-cdp" || cmd === "howto" || cmd === "cdp-help") {
@@ -253,7 +261,7 @@ async function main() {
   }
 
   if (cmd === "status") {
-    const store = new BackgroundStore({ root: dataRoot });
+    const store = new BackgroundStore({ root: requireDataRoot() });
     await store.init();
     const m = await store.readActiveManifest();
     console.log(JSON.stringify(m, null, 2));
@@ -309,10 +317,10 @@ async function main() {
     const onSignal = () => ac.abort();
     process.on("SIGINT", onSignal);
     process.on("SIGTERM", onSignal);
-    console.error(`watching CDP :${port} (dataRoot=${dataRoot}); Ctrl+C to stop`);
+    console.error(`watching CDP :${port} (dataRoot=${requireDataRoot()}); Ctrl+C to stop`);
     await adapter.runWatch({
       port,
-      dataRoot,
+      dataRoot: requireDataRoot(),
       requireAppProtocol: !flags.allowHttp,
       ...(flags.urlPrefix !== undefined ? { urlPrefix: flags.urlPrefix } : {}),
       signal: ac.signal,
@@ -387,7 +395,7 @@ async function main() {
     const result = await adapter.runApplyOnce({
       port,
       input,
-      dataRoot,
+      dataRoot: requireDataRoot(),
       verifyDeadlineMs: flags.verifyMs,
       requireAppProtocol: !flags.allowHttp,
       ...(flags.urlPrefix !== undefined ? { urlPrefix: flags.urlPrefix } : {}),
@@ -397,7 +405,7 @@ async function main() {
     return;
   }
 
-  const store = new BackgroundStore({ root: dataRoot });
+  const store = new BackgroundStore({ root: requireDataRoot() });
   const media = new MediaServerController({ enabled: false });
   const tx = new ApplyTransaction({ store, media, offline: true });
   try {


### PR DESCRIPTION
No hidden default, no LOCALAPPDATA guess in core. Two processes must agree on
one root, so an implicit second copy silently splits them (the DSH-history bug
class this replaces).

- core defaultDataRoot() now throws unless BEAUTICODE_DATA_ROOT is set
- plugin token resolution: config.tokenFile or BEAUTICODE_DATA_ROOT only;
  auth endpoints return 503 with a clear message instead of a generic 401
- tray (as launcher) explicitly defaults -DataRoot to %LOCALAPPDATA%\\beautiCode
  and always passes it to the engine
- CLI: data root lazy (discover/probe stay root-free); help shows required
- docs + installer text updated; drop engine-launcher.log legacy allowance

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>