### PR TITLE
fix: write DSH profile package.json without a UTF-8 BOM

### DIFF
--- a/packages/adapter-dsh/test/launcher-scripts.test.js
+++ b/packages/adapter-dsh/test/launcher-scripts.test.js
@@ -160,6 +160,9 @@ test("install-dsh-plugin wires a missing DSH home and can uninstall", () => {
     const webPatch = fs.readFileSync(path.join(web, "cordis.patch.yml"), "utf8");
     assert.match(webPatch, /@beauticode\/dsh-plugin/);
     assert.equal(fs.existsSync(path.join(home, "cordis.patch.yml")), false);
+    const pkgBytes = fs.readFileSync(path.join(web, "package.json"));
+    assert.notEqual(pkgBytes[0], 0xef, "profile package.json must not have a UTF-8 BOM");
+    JSON.parse(pkgBytes.toString("utf8"));
     assert.ok(
       fs.existsSync(
         path.join(web, "node_modules", "@beauticode", "dsh-plugin", "index.mjs"),

--- a/scripts/install-dsh-plugin.ps1
+++ b/scripts/install-dsh-plugin.ps1
@@ -185,7 +185,11 @@ function Ensure-WebPackageDep {
   }
   if ($current -eq $linkSpec) { return }
   $deps | Add-Member -NotePropertyName $pluginName -NotePropertyValue $linkSpec -Force
-  $json | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $webPackage -Encoding UTF8
+  # Windows PowerShell 5.1 Set-Content -Encoding UTF8 writes a BOM.
+  # DSH reads the profile manifest with JSON.parse and rejects that.
+  $utf8 = New-Object System.Text.UTF8Encoding $false
+  $text = $json | ConvertTo-Json -Depth 8
+  [IO.File]::WriteAllText($webPackage, ($text.TrimEnd() + "`n"), $utf8)
 }
 
 if (-not (Test-Path -LiteralPath $indexFile -PathType Leaf)) {


### PR DESCRIPTION
PowerShell 5.1 的 UTF8 带 BOM，DSH 的 JSON.parse 会在 `dsh web` 时报 Unexpected token。本机 `~\.dsh\profiles\web\package.json` 已去掉 BOM。