### PR TITLE
fix: 托盘与 session-host 同生共死，并修正安装文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,6 @@ beautiCode 可以让你：
 
 <img width="1280" height="808" alt="QQ20260816-201114" src="https://github.com/user-attachments/assets/2faef226-c493-49ef-815b-daec8593a329" />
 
-
-
-
-
-### v1.0.0 安装包
-
-想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/tag/v1.0.0)。
-安装包自带 Node.js，不需要另外安装 Node.js 或 npm。
-Codex Desktop 路径与原来一样：启动后选 **Codex Desktop**，托盘会按需拉起 Codex。
-DeepSeek Harness 由你自己运行：把插件装进 DSH profile，再启动 `dsh web`，然后在选择框里选 **DeepSeek Harness**。beautiCode 绝不替你启动 DSH。页面打开后也可以用 `/bg`、`/bg-theme`、`/bg-clear`，或直接跟 AI 说把本机图片/视频设成背景。
-<img width="533" height="660" alt="image" src="https://github.com/user-attachments/assets/8c16eeb9-94d0-4f19-a816-b32fba8a110c" />
-
-
 ---
 
 ## 摸鱼模式
@@ -160,6 +147,19 @@ Ctrl + Shift + Space
 
 ---
 
+### v1.0.1 安装包
+
+想直接使用 beautiCode，可以下载 [Windows 安装包](https://github.com/starsstreaming/beautiCode/releases/latest)。
+安装包自带 Node.js，不需要另外安装 Node.js、npm 或 pnpm。
+Codex Desktop 路径与原来一样：启动后选 **Codex Desktop**，托盘会按需拉起 Codex。
+DeepSeek Harness 由你自己运行：把插件装进 DSH profile，再启动 `dsh web`，然后在选择框里选 **DeepSeek Harness**。beautiCode 绝不替你启动 DSH。页面打开后可以用 `/bg`、`/bg-theme`、`/bg-clear`，或直接跟 AI 说把本机图片/视频设成背景。
+
+<p align="center">
+  <img width="320" alt="Windows 安装包" src="https://github.com/user-attachments/assets/8c16eeb9-94d0-4f19-a816-b32fba8a110c" />
+</p>
+
+---
+
 ## 使用方式
 
 ### Windows 安装包（推荐）
@@ -167,19 +167,32 @@ Ctrl + Shift + Space
 运行：
 
 ```text
-beautiCode-Setup-1.0.0-win-x64.exe
+beautiCode-Setup-1.0.1-win-x64.exe
 ```
 
-安装包自带 Node.js，不需要另外安装 Node.js 或 npm，也不需要保留项目源码。
-DeepSeek Harness 需要你自己安装并启用插件：
+安装包自带 Node.js，不需要另外安装 Node.js、npm 或 pnpm，也不需要保留项目源码。
+
+安装结束时会自动把 beautiCode 插件写入你的 DeepSeek Harness profile。**一般不需要再执行 `dsh plugin add`，也不需要安装 pnpm。** 若你改过安装目录，以安装文件夹里的 `集成说明.txt` 为准。
+
+然后自己启动 DeepSeek Harness：
 
 ```sh
-dsh plugin --profile web add file:%LOCALAPPDATA%\Programs\beautiCode\integrations\deepseek-harness
-# 在 ~/.dsh/cordis.patch.yml 里加入插件条目（见 integrations/deepseek-harness/cordis.patch.example.yml）
 dsh web
+# 未把 dsh 装到 PATH 时：
+npx @deepseek-ai/dsh web
 ```
 
-安装完成后启动 beautiCode：选 **Codex Desktop** 仍由托盘拉起 Codex；选 **DeepSeek Harness** 则连接你已经启动的 DSH 网页。
+再启动 beautiCode：选 **Codex Desktop** 仍由托盘拉起 Codex；选 **DeepSeek Harness** 则连接你已经启动的 DSH 网页。
+
+若自动写入失败，才需要手动安装插件。把路径换成实际安装目录（默认是 `%LOCALAPPDATA%\Programs\beautiCode`）：
+
+```sh
+# 已全局安装 dsh。这条命令本身会调用 pnpm。
+dsh plugin --profile web add file:%LOCALAPPDATA%\Programs\beautiCode\integrations\deepseek-harness
+
+# 只用 npx，不需要全局 dsh：
+npx @deepseek-ai/dsh plugin --profile web add file:%LOCALAPPDATA%\Programs\beautiCode\integrations\deepseek-harness
+```
 
 之后在托盘里：
 
@@ -199,8 +212,10 @@ dsh web
 
 ```bash
 npm install
-dsh plugin --profile web add file:%CD%/integrations/deepseek-harness
-dsh web
+# 选 DeepSeek Harness 启动托盘时会自动写入插件，不需要 pnpm。
+# 若要手动安装（dsh plugin add 需要 pnpm）：
+#   npx @deepseek-ai/dsh plugin --profile web add file:%CD%/integrations/deepseek-harness
+npx @deepseek-ai/dsh web
 npm run tray
 ```
 

--- a/apps/tray/session-host.mjs
+++ b/apps/tray/session-host.mjs
@@ -28,8 +28,11 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
+  isPidAlive,
   removeDshControlFile,
+  removeSessionHostFile,
   writeDshControlFile,
+  writeSessionHostFile,
 } from "../../integrations/deepseek-harness/control-client.mjs";
 
 if (Number(process.versions.node.split(".", 1)[0]) < 22) {
@@ -62,6 +65,19 @@ delete process.env.BEAUTICODE_CONTROL_TOKEN;
 const portArg = argValue("--port");
 const dshUrl = argValue("--dsh-url") ?? "http://127.0.0.1:3080";
 const dataRoot = argValue("--data-root");
+const parentPidArg = argValue("--parent-pid");
+let parentPid = null;
+if (parentPidArg != null) {
+  parentPid = Number(parentPidArg);
+  if (!Number.isInteger(parentPid) || parentPid < 1) {
+    console.error("--parent-pid 必须是正整数。");
+    process.exit(1);
+  }
+  if (!isPidAlive(parentPid)) {
+    console.error("session-host：父进程已退出。");
+    process.exit(1);
+  }
+}
 const verifyMs = Number(argValue("--verify-ms") ?? "30000");
 if (!Number.isFinite(verifyMs) || verifyMs < 0 || verifyMs > 300_000) {
   console.error("--verify-ms 必须在 0 到 300000 之间。");
@@ -88,7 +104,10 @@ const sessionOpts = {
     console.error(`[session] ${msg}`);
   },
 };
-if (hostKind === "dsh") sessionOpts.baseUrl = dshUrl;
+if (hostKind === "dsh") {
+  sessionOpts.baseUrl = dshUrl;
+  sessionOpts.honorTrayHandoff = false;
+}
 if (portArg) {
   const p = Number(portArg);
   if (!Number.isInteger(p) || p < 1 || p > 65535) {
@@ -430,6 +449,11 @@ async function shutdown(code) {
       /* ignore */
     }
   }
+  try {
+    await removeSessionHostFile({ dataRoot: session.dataRoot, pid: process.pid });
+  } catch {
+    /* ignore */
+  }
   const serverClosed = new Promise((resolve) => server.close(() => resolve()));
   server.closeIdleConnections?.();
   try {
@@ -459,13 +483,35 @@ await new Promise((resolve, reject) => {
 });
 process.on("SIGINT", () => void shutdown(0));
 process.on("SIGTERM", () => void shutdown(0));
+if (parentPid != null) {
+  const parentWatch = setInterval(() => {
+    if (!isPidAlive(parentPid)) void shutdown(0);
+  }, 500);
+  parentWatch.unref?.();
+}
 const addr = server.address();
 const listenPort = typeof addr === "object" && addr ? addr.port : 0;
+const controlUrl = `http://127.0.0.1:${listenPort}`;
+try {
+  await writeSessionHostFile({
+    dataRoot: session.dataRoot,
+    host: hostKind,
+    url: controlUrl,
+    token,
+    pid: process.pid,
+  });
+} catch (error) {
+  console.error(
+    `session-host：无法发布控制面文件：${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+}
 if (hostKind === "dsh") {
   try {
     await writeDshControlFile({
       dataRoot: session.dataRoot,
-      url: `http://127.0.0.1:${listenPort}`,
+      url: controlUrl,
       token,
       pid: process.pid,
     });

--- a/apps/tray/start-tray.ps1
+++ b/apps/tray/start-tray.ps1
@@ -35,6 +35,19 @@ trap {
   $message = if ($_.Exception) { $_.Exception.Message } else { [string]$_ }
   Write-BcTrayLog ("tray failed: {0}" -f $message)
   try {
+    if (Get-Command Stop-BcSessionHost -ErrorAction SilentlyContinue) {
+      Stop-BcSessionHost
+    }
+  } catch { }
+  try {
+    if (Get-Command Remove-BcTrayClaim -ErrorAction SilentlyContinue) {
+      Remove-BcTrayClaim
+    }
+  } catch { }
+  try {
+    if ("BeautiCodeJob" -as [type]) { [BeautiCodeJob]::Close() }
+  } catch { }
+  try {
     Add-Type -AssemblyName System.Windows.Forms -ErrorAction SilentlyContinue
     [System.Windows.Forms.MessageBox]::Show(
       ("beautiCode 托盘启动失败：`n{0}`n`n日志：{1}" -f $message, $script:TrayLogPath),
@@ -46,6 +59,14 @@ trap {
   exit 1
 }
 Write-BcTrayLog "tray starting"
+
+$script:resolvedDataRoot = $null
+$script:sessionHostProc = $null
+$script:sessionHostAdopted = $false
+$script:trayClaimWritten = $false
+$script:Token = $null
+$script:BaseUrl = $null
+$script:controlPort = 0
 
 $script:trayInstanceMutex = $null
 $script:trayInstanceMutexOwned = $false
@@ -62,6 +83,21 @@ $script:trayInstanceMutex = [System.Threading.Mutex]::new(
 )
 if (-not $createdNew) {
   $script:trayInstanceMutex.Dispose()
+  $panelDeadline = [datetime]::UtcNow.AddSeconds(3)
+  while ([datetime]::UtcNow -lt $panelDeadline) {
+    try {
+      $existingPanel = [System.Threading.EventWaitHandle]::OpenExisting(
+        "Local\beautiCode.Engine.ShowPanel.v1"
+      )
+      [void]$existingPanel.Set()
+      $existingPanel.Dispose()
+      Write-BcTrayLog "existing tray signaled to show panel"
+      exit 0
+    } catch [System.Threading.WaitHandleCannotBeOpenedException] {
+      Start-Sleep -Milliseconds 80
+    }
+  }
+  Write-BcTrayLog "existing tray mutex held but show-panel event missing"
   exit 0
 }
 $script:trayInstanceMutexOwned = $true
@@ -127,6 +163,116 @@ public static class BeautiCodeDpiNative {
 '@
 Add-Type -TypeDefinition $dpiNativeCode -ErrorAction Stop
 [void][BeautiCodeDpiNative]::Enable()
+
+$jobNativeCode = @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class BeautiCodeJob {
+  private static IntPtr handle = IntPtr.Zero;
+  private const int JobObjectExtendedLimitInformation = 9;
+  private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+  private const uint PROCESS_TERMINATE = 0x0001;
+  private const uint PROCESS_SET_QUOTA = 0x0100;
+
+  [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+  private static extern IntPtr CreateJobObject(IntPtr attributes, string name);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool SetInformationJobObject(
+    IntPtr job,
+    int infoClass,
+    IntPtr info,
+    uint infoLength
+  );
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern bool CloseHandle(IntPtr value);
+
+  [DllImport("kernel32.dll", SetLastError = true)]
+  private static extern IntPtr OpenProcess(uint access, bool inherit, int processId);
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct JOBOBJECT_BASIC_LIMIT_INFORMATION {
+    public long PerProcessUserTimeLimit;
+    public long PerJobUserTimeLimit;
+    public uint LimitFlags;
+    public UIntPtr MinimumWorkingSetSize;
+    public UIntPtr MaximumWorkingSetSize;
+    public uint ActiveProcessLimit;
+    public UIntPtr Affinity;
+    public uint PriorityClass;
+    public uint SchedulingClass;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct IO_COUNTERS {
+    public ulong ReadOperationCount;
+    public ulong WriteOperationCount;
+    public ulong OtherOperationCount;
+    public ulong ReadTransferCount;
+    public ulong WriteTransferCount;
+    public ulong OtherTransferCount;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+    public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+    public IO_COUNTERS IoInfo;
+    public UIntPtr ProcessMemoryLimit;
+    public UIntPtr JobMemoryLimit;
+    public UIntPtr PeakProcessMemoryUsed;
+    public UIntPtr PeakJobMemoryUsed;
+  }
+
+  public static bool Create() {
+    if (handle != IntPtr.Zero) return true;
+    handle = CreateJobObject(IntPtr.Zero, null);
+    if (handle == IntPtr.Zero) return false;
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION();
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    int length = Marshal.SizeOf(typeof(JOBOBJECT_EXTENDED_LIMIT_INFORMATION));
+    IntPtr buffer = Marshal.AllocHGlobal(length);
+    try {
+      Marshal.StructureToPtr(info, buffer, false);
+      if (!SetInformationJobObject(handle, JobObjectExtendedLimitInformation, buffer, (uint)length)) {
+        CloseHandle(handle);
+        handle = IntPtr.Zero;
+        return false;
+      }
+      return true;
+    } finally {
+      Marshal.FreeHGlobal(buffer);
+    }
+  }
+
+  public static bool Assign(int processId) {
+    if (handle == IntPtr.Zero || processId <= 0) return false;
+    IntPtr process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, processId);
+    if (process == IntPtr.Zero) return false;
+    try {
+      return AssignProcessToJobObject(handle, process);
+    } finally {
+      CloseHandle(process);
+    }
+  }
+
+  public static void Close() {
+    if (handle == IntPtr.Zero) return;
+    CloseHandle(handle);
+    handle = IntPtr.Zero;
+  }
+}
+'@
+if (-not ("BeautiCodeJob" -as [type])) {
+  Add-Type -TypeDefinition $jobNativeCode -ErrorAction Stop
+}
+if (-not [BeautiCodeJob]::Create()) {
+  Write-BcTrayLog "job object create failed; parent-pid watch remains as fallback"
+}
 
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
@@ -347,119 +493,360 @@ if ($script:targetHost -eq "dsh") {
   }
 }
 
-# Cryptographically strong token for the local control plane.
-$rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
-try {
-  $TokenBytes = New-Object byte[] 32
-  $rng.GetBytes($TokenBytes)
-} finally {
-  $rng.Dispose()
-}
-$Token = -join ($TokenBytes | ForEach-Object { $_.ToString("x2") })
-
 function ConvertTo-PsLiteral([string]$Value) {
   return "'" + ($Value -replace "'", "''") + "'"
 }
 
-$nodeInvocationParts = @(
-  (ConvertTo-PsLiteral $Node),
-  (ConvertTo-PsLiteral $HostScript),
-  "--host",
-  $TargetHost
-)
-if ($TargetHost -eq "dsh") {
-  $nodeInvocationParts += @("--dsh-url", (ConvertTo-PsLiteral $DshUrl))
-}
-if ($Port -gt 0) {
-  $nodeInvocationParts += @("--port", "$Port")
-}
-if ($DataRoot) {
-  $nodeInvocationParts += @("--data-root", (ConvertTo-PsLiteral $DataRoot))
+function Get-BcTrayDataRoot {
+  if ($script:resolvedDataRoot) { return $script:resolvedDataRoot }
+  $root = $null
+  if ($DataRoot) { $root = $DataRoot }
+  elseif ($env:BEAUTICODE_DATA_ROOT) { $root = $env:BEAUTICODE_DATA_ROOT }
+  elseif ($env:LOCALAPPDATA) { $root = Join-Path $env:LOCALAPPDATA "beautiCode" }
+  else { $root = Join-Path $env:USERPROFILE ".beauticode" }
+  $script:resolvedDataRoot = [IO.Path]::GetFullPath($root)
+  return $script:resolvedDataRoot
 }
 
-# Windows PowerShell 5.1 can throw while reading ProcessStartInfo.EnvironmentVariables
-# when the inherited process has both Path and PATH. Start a tiny PowerShell bridge,
-# pass the token through stdin, and let that bridge set the child-only environment.
-$nodeInvocation = [string]::Join(" ", $nodeInvocationParts)
-$bridgeScript = @"
+function Read-BcJsonFile([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $null }
+  try {
+    return (Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json)
+  } catch {
+    return $null
+  }
+}
+
+function Test-BcPidAlive([int]$ProcId) {
+  if ($ProcId -le 0) { return $false }
+  try {
+    Get-Process -Id $ProcId -ErrorAction Stop | Out-Null
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Test-BcSessionHostPid([int]$ProcId) {
+  if ($ProcId -le 0) { return $false }
+  try {
+    $info = Get-CimInstance Win32_Process -Filter ("ProcessId = {0}" -f $ProcId) -ErrorAction Stop
+    return ($info.CommandLine -and ($info.CommandLine -match 'session-host\.mjs'))
+  } catch {
+    return $false
+  }
+}
+
+function Get-BcInjectorLockPid {
+  $lockFile = Join-Path (Get-BcTrayDataRoot) "injector.lock"
+  $json = Read-BcJsonFile $lockFile
+  if (-not $json) { return 0 }
+  try { return [int]$json.pid } catch { return 0 }
+}
+
+function Get-BcExistingControl {
+  $root = Get-BcTrayDataRoot
+  foreach ($name in @("session-host.json", "dsh-control.json")) {
+    $json = Read-BcJsonFile (Join-Path $root $name)
+    if (-not $json) { continue }
+    if (-not $json.url -or -not $json.token) { continue }
+    $ownerPid = 0
+    try { $ownerPid = [int]$json.pid } catch { continue }
+    if (-not (Test-BcPidAlive $ownerPid)) { continue }
+    return $json
+  }
+  return $null
+}
+
+function Test-BcControlHealth([string]$Url, [string]$ControlToken) {
+  if (-not $Url -or -not $ControlToken) { return $false }
+  try {
+    $headers = @{ Authorization = ("Bearer {0}" -f $ControlToken) }
+    $response = Invoke-RestMethod -Uri ("{0}/health" -f $Url.TrimEnd("/")) -Headers $headers -TimeoutSec 2
+    return ($response.ok -eq $true)
+  } catch {
+    return $false
+  }
+}
+
+function Use-BcAdoptedControl($Control) {
+  $origin = [string]$Control.url
+  try {
+    $uri = [Uri]$Control.url
+    $origin = $uri.GetLeftPart([System.UriPartial]::Authority)
+    $script:controlPort = [int]$uri.Port
+  } catch {
+    $script:controlPort = 0
+  }
+  $script:sessionHostAdopted = $true
+  $script:Token = [string]$Control.token
+  $script:BaseUrl = $origin.TrimEnd("/")
+  $script:cdpPort = 0
+  $ownerPid = 0
+  try { $ownerPid = [int]$Control.pid } catch { $ownerPid = 0 }
+  if ($ownerPid -gt 0) {
+    if (-not [BeautiCodeJob]::Assign($ownerPid)) {
+      Write-BcTrayLog ("adopted session-host job assign failed pid={0}" -f $ownerPid)
+    }
+  }
+  Write-BcTrayLog ("adopted existing session-host url={0} pid={1}" -f $script:BaseUrl, $ownerPid)
+}
+
+function Stop-BcLeftoverEngine([int]$ProcId) {
+  if ($ProcId -le 0) { return }
+  if (-not (Test-BcSessionHostPid $ProcId)) { return }
+  Write-BcTrayLog ("stopping leftover session-host pid={0}" -f $ProcId)
+  try { Stop-Process -Id $ProcId -Force -ErrorAction Stop } catch { }
+  $deadline = [datetime]::UtcNow.AddSeconds(3)
+  while ([datetime]::UtcNow -lt $deadline) {
+    if (-not (Test-BcPidAlive $ProcId)) { return }
+    Start-Sleep -Milliseconds 80
+  }
+}
+
+function Write-BcTrayClaim {
+  $root = Get-BcTrayDataRoot
+  if (-not (Test-Path -LiteralPath $root)) {
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+  }
+  $payload = @{
+    schema = "beauticode.tray-claim/v1"
+    pid = [int]$PID
+    startedAt = [datetime]::UtcNow.ToString("o")
+  } | ConvertTo-Json -Compress
+  $utf8 = New-Object System.Text.UTF8Encoding $false
+  [IO.File]::WriteAllText((Join-Path $root "tray-claim.json"), ($payload + "`n"), $utf8)
+  $script:trayClaimWritten = $true
+}
+
+function Remove-BcTrayClaim {
+  $root = $script:resolvedDataRoot
+  if (-not $root) { return }
+  $file = Join-Path $root "tray-claim.json"
+  try {
+    if (Test-Path -LiteralPath $file -PathType Leaf) {
+      $json = Read-BcJsonFile $file
+      if (-not $json -or [int]$json.pid -eq [int]$PID) {
+        Remove-Item -LiteralPath $file -Force -ErrorAction SilentlyContinue
+      }
+    }
+  } catch { }
+  $script:trayClaimWritten = $false
+}
+
+function Stop-BcSessionHost {
+  if ($script:BaseUrl -and $script:Token) {
+    try {
+      $headers = @{ Authorization = ("Bearer {0}" -f $script:Token) }
+      $utf8 = New-Object System.Text.UTF8Encoding $false
+      $bytes = $utf8.GetBytes("{}")
+      Invoke-RestMethod -Uri ("{0}/shutdown" -f $script:BaseUrl.TrimEnd("/")) `
+        -Method Post -Headers $headers -ContentType "application/json; charset=utf-8" `
+        -Body $bytes -TimeoutSec 2 | Out-Null
+    } catch { }
+    Start-Sleep -Milliseconds 250
+  }
+  if ($null -ne $script:sessionHostProc) {
+    try {
+      if (-not $script:sessionHostProc.HasExited) { $script:sessionHostProc.Kill() }
+    } catch { }
+  }
+}
+
+function Test-BcCanAdopt($Control) {
+  if (-not $Control) { return $false }
+  $controlHost = [string]$Control.host
+  if ($controlHost -and $controlHost -ne $TargetHost) { return $false }
+  return (Test-BcControlHealth -Url ([string]$Control.url) -ControlToken ([string]$Control.token))
+}
+
+function Resolve-BcSessionHost {
+  Write-BcTrayClaim
+  $deadline = [datetime]::UtcNow.AddSeconds(15)
+  while ([datetime]::UtcNow -lt $deadline) {
+    $existing = Get-BcExistingControl
+    if (Test-BcCanAdopt $existing) {
+      Use-BcAdoptedControl $existing
+      return
+    }
+    if ($existing -and $existing.host -and ([string]$existing.host -ne $TargetHost)) {
+      try { Stop-BcLeftoverEngine ([int]$existing.pid) } catch { }
+    }
+    $lockPid = Get-BcInjectorLockPid
+    if ($lockPid -gt 0 -and (Test-BcSessionHostPid $lockPid)) {
+      $lockControl = Get-BcExistingControl
+      if (-not (Test-BcCanAdopt $lockControl)) {
+        Stop-BcLeftoverEngine $lockPid
+      }
+    }
+    if ($lockPid -le 0 -or -not (Test-BcPidAlive $lockPid)) { break }
+    Start-Sleep -Milliseconds 200
+  }
+}
+
+function New-BcControlToken {
+  $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+  try {
+    $tokenBytes = New-Object byte[] 32
+    $rng.GetBytes($tokenBytes)
+  } finally {
+    $rng.Dispose()
+  }
+  return -join ($tokenBytes | ForEach-Object { $_.ToString("x2") })
+}
+
+function Start-BcSessionHostProcess([string]$ControlToken) {
+  $resolvedRoot = Get-BcTrayDataRoot
+  $nodeInvocationParts = @(
+    (ConvertTo-PsLiteral $Node),
+    (ConvertTo-PsLiteral $HostScript),
+    "--host",
+    $TargetHost,
+    "--parent-pid",
+    "$PID",
+    "--data-root",
+    (ConvertTo-PsLiteral $resolvedRoot)
+  )
+  if ($TargetHost -eq "dsh") {
+    $nodeInvocationParts += @("--dsh-url", (ConvertTo-PsLiteral $DshUrl))
+  }
+  if ($Port -gt 0) {
+    $nodeInvocationParts += @("--port", "$Port")
+  }
+
+  # Windows PowerShell 5.1 can throw while reading ProcessStartInfo.EnvironmentVariables
+  # when the inherited process has both Path and PATH. Start a tiny PowerShell bridge,
+  # pass the token through stdin, and let that bridge set the child-only environment.
+  $nodeInvocation = [string]::Join(" ", $nodeInvocationParts)
+  $bridgeScript = @"
 `$token = [Console]::In.ReadToEnd()
 if ([string]::IsNullOrWhiteSpace(`$token)) { throw "缺少 beautiCode 控制令牌。" }
 `$env:BEAUTICODE_CONTROL_TOKEN = `$token.Trim()
 & $nodeInvocation
 exit `$LASTEXITCODE
 "@
-$bridgeBytes = [System.Text.Encoding]::Unicode.GetBytes($bridgeScript)
-$bridgeCommand = [Convert]::ToBase64String($bridgeBytes)
-$powershell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+  $bridgeBytes = [System.Text.Encoding]::Unicode.GetBytes($bridgeScript)
+  $bridgeCommand = [Convert]::ToBase64String($bridgeBytes)
+  $powershell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
 
-$psi = New-Object System.Diagnostics.ProcessStartInfo
-$psi.FileName = $powershell
-$psi.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $bridgeCommand"
-$psi.WorkingDirectory = $RepoRoot
-$psi.UseShellExecute = $false
-$psi.RedirectStandardInput = $true
-$psi.RedirectStandardOutput = $true
-$psi.RedirectStandardError = $true
-$psi.CreateNoWindow = $true
+  $psi = New-Object System.Diagnostics.ProcessStartInfo
+  $psi.FileName = $powershell
+  $psi.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $bridgeCommand"
+  $psi.WorkingDirectory = $RepoRoot
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardInput = $true
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+  $psi.CreateNoWindow = $true
 
-$proc = New-Object System.Diagnostics.Process
-$proc.StartInfo = $psi
-
-$stdoutSync = [hashtable]::Synchronized(@{ Lines = New-Object System.Collections.ArrayList })
-$stderrSync = [hashtable]::Synchronized(@{ Lines = New-Object System.Collections.ArrayList })
-
-$outEvent = Register-ObjectEvent -InputObject $proc -EventName OutputDataReceived -MessageData $stdoutSync -Action {
-  $line = $EventArgs.Data
-  if (-not [string]::IsNullOrEmpty($line)) {
-    [void]$Event.MessageData.Lines.Add($line)
-  }
-}
-$errEvent = Register-ObjectEvent -InputObject $proc -EventName ErrorDataReceived -MessageData $stderrSync -Action {
-  $line = $EventArgs.Data
-  if (-not [string]::IsNullOrEmpty($line)) {
-    [void]$Event.MessageData.Lines.Add($line)
-  }
-}
-
-[void]$proc.Start()
-$proc.BeginOutputReadLine()
-$proc.BeginErrorReadLine()
-$proc.StandardInput.WriteLine($Token)
-$proc.StandardInput.Close()
-
-$ready = $null
-$deadline = [datetime]::UtcNow.AddSeconds(20)
-while ([datetime]::UtcNow -lt $deadline) {
-  if ($proc.HasExited) {
-    $errDump = [string]::Join([Environment]::NewLine, @($stderrSync.Lines))
-    $msg = "session-host exited early ({0}).{1}{2}" -f $proc.ExitCode, [Environment]::NewLine, $errDump
-    throw $msg
-  }
-  foreach ($line in @($stdoutSync.Lines)) {
-    if (($line -match '^\s*\{') -and ($line -match '"ready"')) {
-      try {
-        $ready = $line | ConvertFrom-Json
-        break
-      } catch {
-        # keep waiting
-      }
+  $child = New-Object System.Diagnostics.Process
+  $child.StartInfo = $psi
+  $stdoutSync = [hashtable]::Synchronized(@{ Lines = New-Object System.Collections.ArrayList })
+  $stderrSync = [hashtable]::Synchronized(@{ Lines = New-Object System.Collections.ArrayList })
+  $outEvent = Register-ObjectEvent -InputObject $child -EventName OutputDataReceived -MessageData $stdoutSync -Action {
+    $line = $EventArgs.Data
+    if (-not [string]::IsNullOrEmpty($line)) {
+      [void]$Event.MessageData.Lines.Add($line)
     }
   }
-  if ($ready -and $ready.ready) { break }
-  Start-Sleep -Milliseconds 40
+  $errEvent = Register-ObjectEvent -InputObject $child -EventName ErrorDataReceived -MessageData $stderrSync -Action {
+    $line = $EventArgs.Data
+    if (-not [string]::IsNullOrEmpty($line)) {
+      [void]$Event.MessageData.Lines.Add($line)
+    }
+  }
+
+  [void]$child.Start()
+  $script:sessionHostProc = $child
+  if (-not [BeautiCodeJob]::Assign($child.Id)) {
+    Write-BcTrayLog ("job assign failed pid={0}" -f $child.Id)
+  }
+  $child.BeginOutputReadLine()
+  $child.BeginErrorReadLine()
+  $child.StandardInput.WriteLine($ControlToken)
+  $child.StandardInput.Close()
+
+  $ready = $null
+  $waitUntil = [datetime]::UtcNow.AddSeconds(20)
+  while ([datetime]::UtcNow -lt $waitUntil) {
+    if ($child.HasExited) {
+      $errDump = [string]::Join([Environment]::NewLine, @($stderrSync.Lines))
+      throw ("session-host exited early ({0}).{1}{2}" -f $child.ExitCode, [Environment]::NewLine, $errDump)
+    }
+    foreach ($line in @($stdoutSync.Lines)) {
+      if (($line -match '^\s*\{') -and ($line -match '"ready"')) {
+        try {
+          $ready = $line | ConvertFrom-Json
+          break
+        } catch { }
+      }
+    }
+    if ($ready -and $ready.ready) { break }
+    Start-Sleep -Milliseconds 40
+  }
+
+  if (-not $ready -or -not $ready.ready) {
+    try { if (-not $child.HasExited) { $child.Kill() } } catch { }
+    throw "等待 session-host 就绪超时。"
+  }
+  return @{
+    Ready = $ready
+    Process = $child
+    OutEvent = $outEvent
+    ErrEvent = $errEvent
+  }
 }
 
-if (-not $ready -or -not $ready.ready) {
-  try { if (-not $proc.HasExited) { $proc.Kill() } } catch { }
-  throw "等待 session-host 就绪超时。"
+Resolve-BcSessionHost
+
+$proc = $null
+$outEvent = $null
+$errEvent = $null
+$ready = $null
+
+if (-not $script:sessionHostAdopted) {
+  $Token = New-BcControlToken
+  $script:Token = $Token
+  $started = $null
+  try {
+    $started = Start-BcSessionHostProcess -ControlToken $Token
+  } catch {
+    $firstError = $_
+    Write-BcTrayLog ("session-host start failed: {0}" -f $firstError.Exception.Message)
+    $existing = Get-BcExistingControl
+    if (Test-BcCanAdopt $existing) {
+      Use-BcAdoptedControl $existing
+    } else {
+      Stop-BcLeftoverEngine (Get-BcInjectorLockPid)
+      $started = Start-BcSessionHostProcess -ControlToken $Token
+    }
+  }
+  if (-not $script:sessionHostAdopted) {
+    $ready = $started.Ready
+    $proc = $started.Process
+    $outEvent = $started.OutEvent
+    $errEvent = $started.ErrEvent
+    $script:sessionHostProc = $proc
+  }
 }
 
-$controlPort = [int]$ready.controlPort
-$cdpPort = if ($null -ne $ready.cdpPort) { [int]$ready.cdpPort } else { 0 }
-$script:cdpPort = $cdpPort
-$BaseUrl = "http://127.0.0.1:$controlPort"
+if ($script:sessionHostAdopted) {
+  $Token = $script:Token
+  $BaseUrl = $script:BaseUrl
+  $controlPort = [int]$script:controlPort
+  $cdpPort = 0
+  $script:cdpPort = 0
+} else {
+  $controlPort = [int]$ready.controlPort
+  $cdpPort = if ($null -ne $ready.cdpPort) { [int]$ready.cdpPort } else { 0 }
+  $script:cdpPort = $cdpPort
+  $BaseUrl = "http://127.0.0.1:$controlPort"
+  $script:BaseUrl = $BaseUrl
+  $script:Token = $Token
+  $script:controlPort = $controlPort
+}
 Write-Host ("Tray control plane {0} (host: {1})" -f $BaseUrl, $TargetHost)
-Write-BcTrayLog ("session-host ready host={0} controlPort={1} cdpPort={2}" -f $TargetHost, $controlPort, $cdpPort)
+Write-BcTrayLog ("session-host ready host={0} controlPort={1} cdpPort={2} adopted={3}" -f $TargetHost, $controlPort, $cdpPort, [bool]$script:sessionHostAdopted)
 
 function Invoke-BcApi {
   param(
@@ -1008,8 +1395,8 @@ $L = @{
   RestartConfirm = (U "0043 0068 0061 0074 0047 0050 0054 002F 0043 006F 0064 0065 0078 0020 6B63 5728 8FD0 884C 3002 91CD 542F 53EF 80FD 4E22 5931 672A 4FDD 5B58 5185 5BB9 3002 662F 5426 7EE7 7EED FF1F")
   ForceCloseConfirm = (U "5E94 7528 672A 5728 0020 0035 0020 79D2 5185 9000 51FA 3002 662F 5426 5F3A 5236 7ED3 675F 5269 4F59 8FDB 7A0B FF1F")
   RestartCancelled = (U "5DF2 53D6 6D88 91CD 542F 3002")
-  RunningTip     = (U "6258 76D8 5DF2 542F 52A8 3002 0043 0074 0072 006C 002B 0053 0068 0069 0066 0074 002B 0053 0070 0061 0063 0065 0020 6478 9C7C 3002") # 托盘已启动。Ctrl+Shift+Space 摸鱼。
-  RunningTipDsh  = (U "6258 76D8 5DF2 542F 52A8 3002 8BF7 5148 6253 5F00 0020 0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7F51 9875 3002") # 托盘已启动。请先打开 DeepSeek Harness 网页。
+  RunningTip     = (U "6258 76D8 5DF2 542F 52A8 3002 56FE 6807 5728 53F3 4E0B 89D2 FF0C 0057 0069 006E 0031 0031 0020 53EF 80FD 5728 0020 005E 0020 91CC 3002 0043 0074 0072 006C 002B 0053 0068 0069 0066 0074 002B 0053 0070 0061 0063 0065 0020 6478 9C7C 3002") # 托盘已启动。图标在右下角，Win11 可能在 ^ 里。Ctrl+Shift+Space 摸鱼。
+  RunningTipDsh  = (U "6258 76D8 5DF2 542F 52A8 3002 56FE 6807 5728 53F3 4E0B 89D2 FF08 0057 0069 006E 0031 0031 0020 53EF 80FD 5728 0020 005E 0020 91CC FF09 3002 8BF7 5148 6253 5F00 0020 0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7F51 9875 3002") # 托盘已启动。图标在右下角（Win11 可能在 ^ 里）。请先打开 DeepSeek Harness 网页。
   HostCodex      = "Codex Desktop"
   HostDsh        = "DeepSeek Harness"
   DshPhaseOne    = (U "0044 0065 0065 0070 0053 0065 0065 006B 0020 0048 0061 0072 006E 0065 0073 0073 0020 7B2C 4E00 9636 6BB5 4EC5 652F 6301 56FE 7247 80CC 666F 3001 6E05 9664 548C 91CD 65B0 5E94 7528 3002") # DeepSeek Harness 第一阶段仅支持图片背景、清除和重新应用。
@@ -2530,29 +2917,18 @@ try {
 } finally {
   Unregister-BcFishHotkey
   try {
-    if (-not $proc.HasExited) {
-      # Best-effort leave fish before shutdown (session.stop also restores).
+    if ($script:BaseUrl -and $script:Token -and $script:fishMode) {
       try {
-        if ($script:fishMode) {
-          Invoke-BcApi -Method Post -Path "/mode/fish" -Body @{ enabled = $false } | Out-Null
-          $script:fishMode = $false
-        }
-      } catch {
-        # ignore
-      }
-      try {
-        Invoke-BcApi -Method Post -Path "/shutdown" -Body @{} | Out-Null
-      } catch {
-        # ignore
-      }
-      Start-Sleep -Milliseconds 300
-      if (-not $proc.HasExited) {
-        try { $proc.Kill() } catch { }
-      }
+        Invoke-BcApi -Method Post -Path "/mode/fish" -Body @{ enabled = $false } | Out-Null
+        $script:fishMode = $false
+      } catch { }
     }
+    Stop-BcSessionHost
   } catch {
     # ignore
   }
+  try { Remove-BcTrayClaim } catch { }
+  try { [BeautiCodeJob]::Close() } catch { }
   try {
     $notify.Visible = $false
     $notify.Dispose()

--- a/docs/deepseek-harness.md
+++ b/docs/deepseek-harness.md
@@ -17,17 +17,23 @@ beautiCode 通过 DeepSeek Harness 的 Cordis 插件接口接入（`@beauticode/
 
 ## 安装插件
 
-Windows 安装包会在安装结束时（以及选择 DeepSeek Harness 时）自动写入你的 DSH profile。没有 DSH 也不影响安装；第一次运行 `dsh web` 会走 home 层补丁。也可手动：
+Windows 安装包会在安装结束时（以及选择 DeepSeek Harness 时）自动写入你的 DSH profile，**不需要 pnpm，也不需要再跑 `dsh plugin add`**。没有 DSH 也不影响安装；第一次运行 `dsh web` 会走 home 层补丁。
+
+若改过安装目录，看安装文件夹里的 `集成说明.txt`，不要照抄默认路径。
+
+也可手动（`dsh plugin add` 需要本机有 pnpm）：
 
 ```sh
 # 源码目录
 dsh plugin --profile web add file:<beautiCode 路径>/integrations/deepseek-harness
+npx @deepseek-ai/dsh plugin --profile web add file:<beautiCode 路径>/integrations/deepseek-harness
 
-# Windows 安装包
+# Windows 安装包（默认目录；自定义安装时请替换路径）
 dsh plugin --profile web add file:%LOCALAPPDATA%\Programs\beautiCode\integrations\deepseek-harness
+npx @deepseek-ai/dsh plugin --profile web add file:%LOCALAPPDATA%\Programs\beautiCode\integrations\deepseek-harness
 ```
 
-包尚未发布到 npm，请按路径安装。
+包尚未发布到 npm，请按路径安装。未把 `dsh` 装到 PATH 时，用上面的 `npx @deepseek-ai/dsh` 写法。
 
 ## 启用插件
 

--- a/docs/windows-installer.md
+++ b/docs/windows-installer.md
@@ -17,8 +17,11 @@ yourself. Codex Desktop is optional and remains a separate prerequisite if you
 choose that host; the tray still launches Codex as before.
 
 The installer creates a Start menu shortcut. Desktop and login-start shortcuts
-are optional installer tasks. Uninstall removes program files and shortcuts but
-preserves `%LOCALAPPDATA%\beautiCode`, which contains user media and themes.
+are optional installer tasks. After install it writes `集成说明.txt` into `{app}`
+with the actual plugin path, `dsh` / `npx` commands, and a note that pnpm is
+not required for the automatic wiring. Uninstall removes program files and
+shortcuts but preserves `%LOCALAPPDATA%\beautiCode`, which contains user media
+and themes.
 Quit the beautiCode tray before an upgrade or uninstall so the bundled runtime
 is not in use.
 

--- a/installer/windows/beauticode.iss
+++ b/installer/windows/beauticode.iss
@@ -58,8 +58,8 @@ Name: "{autodesktop}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powers
 Name: "{userstartup}\beautiCode"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode-engine.ps1"" -NoLaunchCodex"; WorkingDir: "{app}"; IconFilename: "{app}\beauticode.ico"; Tasks: autostart
 
 [Run]
-Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\install-dsh-plugin.ps1"" -PluginRoot ""{app}\integrations\deepseek-harness"""; WorkingDir: "{app}"; StatusMsg: "正在把 beautiCode 插件写入 DeepSeek Harness…"; Flags: postinstall runhidden
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\install-dsh-plugin.ps1"" -PluginRoot ""{app}\integrations\deepseek-harness"" -InstallRoot ""{app}"""; WorkingDir: "{app}"; StatusMsg: "正在把 beautiCode 插件写入 DeepSeek Harness…"; Flags: postinstall runhidden
 Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""{app}\scripts\start-beauticode.ps1"""; WorkingDir: "{app}"; Description: "启动 beautiCode"; Flags: postinstall nowait skipifsilent
 
 [UninstallRun]
-Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\install-dsh-plugin.ps1"" -PluginRoot ""{app}\integrations\deepseek-harness"" -Remove"; WorkingDir: "{app}"; Flags: runhidden
+Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\install-dsh-plugin.ps1"" -PluginRoot ""{app}\integrations\deepseek-harness"" -InstallRoot ""{app}"" -Remove"; WorkingDir: "{app}"; Flags: runhidden

--- a/integrations/deepseek-harness/README.zh-CN.md
+++ b/integrations/deepseek-harness/README.zh-CN.md
@@ -6,11 +6,13 @@
 
 beautiCode **不启动** DeepSeek Harness。请先自己运行 `dsh web`，再打开 beautiCode 选择 DeepSeek Harness。
 
-安装包和托盘会把插件写入你的 DSH profile。源码环境也可以手动：
+安装包和托盘会把插件写入你的 DSH profile，不需要 pnpm。源码环境也可以手动（`dsh plugin add` 需要 pnpm）：
 
 ```sh
 dsh plugin --profile web add file:%CD%/integrations/deepseek-harness
-dsh web
+# 或
+npx @deepseek-ai/dsh plugin --profile web add file:%CD%/integrations/deepseek-harness
+npx @deepseek-ai/dsh web
 ```
 
 手动接入时：

--- a/integrations/deepseek-harness/control-client.mjs
+++ b/integrations/deepseek-harness/control-client.mjs
@@ -5,8 +5,13 @@ import path from "node:path";
 
 export const CONTROL_SCHEMA = "beauticode.dsh-control/v1";
 export const CONTROL_FILE = "dsh-control.json";
+export const SESSION_HOST_SCHEMA = "beauticode.session-host/v1";
+export const SESSION_HOST_FILE = "session-host.json";
+export const TRAY_CLAIM_SCHEMA = "beauticode.tray-claim/v1";
+export const TRAY_CLAIM_FILE = "tray-claim.json";
 export const TRAY_MISSING_MESSAGE =
   "未找到正在运行的 beautiCode 托盘。请先启动 beautiCode，再导入背景。";
+export const TRAY_STARTING_MESSAGE = "beautiCode 托盘正在启动，请稍后再试。";
 
 const IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".avif"]);
 const TOKEN_MIN_LENGTH = 24;
@@ -24,6 +29,37 @@ export function defaultBeauticodeDataRoot() {
 
 export function controlFilePath(dataRoot) {
   return path.join(path.resolve(dataRoot), CONTROL_FILE);
+}
+
+export function sessionHostFilePath(dataRoot) {
+  return path.join(path.resolve(dataRoot), SESSION_HOST_FILE);
+}
+
+export function trayClaimFilePath(dataRoot) {
+  return path.join(path.resolve(dataRoot), TRAY_CLAIM_FILE);
+}
+
+async function writeAtomicJson(dataRoot, fileName, payload) {
+  await fs.mkdir(dataRoot, { recursive: true });
+  const file = path.join(dataRoot, fileName);
+  const tmp = path.join(
+    dataRoot,
+    `.${fileName}.${process.pid}.${crypto.randomBytes(8).toString("hex")}.tmp`,
+  );
+  const handle = await fs.open(tmp, "w", 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(payload)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await fs.unlink(file);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code !== "ENOENT") throw error;
+  }
+  await fs.rename(tmp, file);
+  return file;
 }
 
 export function isLoopbackControlUrl(value) {
@@ -153,33 +189,50 @@ export async function writeDshControlFile(opts) {
   if (!Number.isInteger(pid) || pid <= 0) {
     throw new Error("DSH control pid is invalid.");
   }
-  await fs.mkdir(dataRoot, { recursive: true });
-  const file = controlFilePath(dataRoot);
-  const payload = `${JSON.stringify({
+  return writeAtomicJson(dataRoot, CONTROL_FILE, {
     schema: CONTROL_SCHEMA,
     host: "dsh",
     pid,
     url: new URL(url).origin,
     token,
-  })}\n`;
-  const tmp = path.join(
-    dataRoot,
-    `.${CONTROL_FILE}.${pid}.${crypto.randomBytes(8).toString("hex")}.tmp`,
-  );
-  const handle = await fs.open(tmp, "w", 0o600);
-  try {
-    await handle.writeFile(payload, "utf8");
-    await handle.sync();
-  } finally {
-    await handle.close();
+  });
+}
+
+export async function writeSessionHostFile(opts) {
+  const dataRoot = path.resolve(opts.dataRoot);
+  const url = opts.url;
+  const token = opts.token;
+  const pid = opts.pid ?? process.pid;
+  const host = opts.host === "codex" ? "codex" : "dsh";
+  if (!isLoopbackControlUrl(url)) {
+    throw new Error("session-host URL must be loopback HTTP.");
   }
-  try {
-    await fs.unlink(file);
-  } catch (error) {
-    if (error && typeof error === "object" && error.code !== "ENOENT") throw error;
+  if (typeof token !== "string" || token.length < TOKEN_MIN_LENGTH) {
+    throw new Error("session-host token is too short.");
   }
-  await fs.rename(tmp, file);
-  return file;
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error("session-host pid is invalid.");
+  }
+  return writeAtomicJson(dataRoot, SESSION_HOST_FILE, {
+    schema: SESSION_HOST_SCHEMA,
+    host,
+    pid,
+    url: new URL(url).origin,
+    token,
+  });
+}
+
+export async function writeTrayClaim(opts) {
+  const dataRoot = path.resolve(opts.dataRoot);
+  const pid = opts.pid ?? process.pid;
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error("tray claim pid is invalid.");
+  }
+  return writeAtomicJson(dataRoot, TRAY_CLAIM_FILE, {
+    schema: TRAY_CLAIM_SCHEMA,
+    pid,
+    startedAt: new Date().toISOString(),
+  });
 }
 
 export async function removeDshControlFile(opts) {
@@ -232,6 +285,104 @@ export async function readDshControlFile(dataRoot, opts = {}) {
     url: new URL(parsed.url).origin,
     token: parsed.token,
   };
+}
+
+export async function removeSessionHostFile(opts) {
+  const dataRoot = path.resolve(opts.dataRoot);
+  const pid = opts.pid ?? process.pid;
+  const file = sessionHostFilePath(dataRoot);
+  try {
+    const current = await readSessionHostFile(dataRoot, { allowDead: true });
+    if (!current || current.pid !== pid) return false;
+    await fs.unlink(file);
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function readSessionHostFile(dataRoot, opts = {}) {
+  const file = sessionHostFilePath(dataRoot);
+  let raw;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return null;
+    throw error;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    !parsed ||
+    parsed.schema !== SESSION_HOST_SCHEMA ||
+    (parsed.host !== "dsh" && parsed.host !== "codex") ||
+    typeof parsed.token !== "string" ||
+    parsed.token.length < TOKEN_MIN_LENGTH ||
+    !isLoopbackControlUrl(parsed.url) ||
+    !Number.isInteger(parsed.pid) ||
+    parsed.pid <= 0
+  ) {
+    return null;
+  }
+  if (!opts.allowDead && !isPidAlive(parsed.pid)) return null;
+  return {
+    schema: SESSION_HOST_SCHEMA,
+    host: parsed.host,
+    pid: parsed.pid,
+    url: new URL(parsed.url).origin,
+    token: parsed.token,
+  };
+}
+
+export async function readTrayClaim(dataRoot, opts = {}) {
+  const file = trayClaimFilePath(dataRoot);
+  let raw;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return null;
+    throw error;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    !parsed ||
+    parsed.schema !== TRAY_CLAIM_SCHEMA ||
+    !Number.isInteger(parsed.pid) ||
+    parsed.pid <= 0
+  ) {
+    return null;
+  }
+  if (!opts.allowDead && !isPidAlive(parsed.pid)) return null;
+  return {
+    schema: TRAY_CLAIM_SCHEMA,
+    pid: parsed.pid,
+    startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : null,
+  };
+}
+
+export async function removeTrayClaim(opts) {
+  const dataRoot = path.resolve(opts.dataRoot);
+  const pid = opts.pid ?? process.pid;
+  const file = trayClaimFilePath(dataRoot);
+  try {
+    const current = await readTrayClaim(dataRoot, { allowDead: true });
+    if (!current || current.pid !== pid) return false;
+    await fs.unlink(file);
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 function mergeSignals(userSignal, timeoutMs) {

--- a/integrations/deepseek-harness/host-apply.mjs
+++ b/integrations/deepseek-harness/host-apply.mjs
@@ -1,5 +1,10 @@
 import path from "node:path";
-import { callDshControl, readDshControlFile } from "./control-client.mjs";
+import {
+  TRAY_STARTING_MESSAGE,
+  callDshControl,
+  readDshControlFile,
+  readTrayClaim,
+} from "./control-client.mjs";
 
 const sessions = new Map();
 
@@ -54,13 +59,32 @@ export async function hasLiveTray(dataRoot) {
   }
 }
 
+export async function hasLiveTrayClaim(dataRoot) {
+  return Boolean(await readTrayClaim(dataRoot));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function ensureInProcessSession(options) {
   const dataRoot = path.resolve(options.dataRoot);
   const baseUrl = options.baseUrl || "http://127.0.0.1:3080";
   const key = sessionKey(dataRoot);
   const current = sessions.get(key);
-  if (current?.session?.isOpen) return current.session;
-  if (current?.promise) return current.promise;
+  if (current?.session && !current.session.isOpen) {
+    sessions.delete(key);
+  } else if (current?.session?.isOpen) {
+    return current.session;
+  } else if (current?.promise) {
+    return current.promise;
+  }
+
+  if (await hasLiveTray(dataRoot) || await hasLiveTrayClaim(dataRoot)) {
+    const error = new Error(TRAY_STARTING_MESSAGE);
+    error.code = "TRAY_CLAIMED";
+    throw error;
+  }
 
   const promise = (async () => {
     const adapter = await loadAdapter();
@@ -110,6 +134,20 @@ export async function stopInProcessSession(dataRoot) {
 export async function resolveApplyBackend(options) {
   if (await hasLiveTray(options.dataRoot)) {
     return { kind: "tray" };
+  }
+  if (await hasLiveTrayClaim(options.dataRoot)) {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      if (await hasLiveTray(options.dataRoot)) {
+        return { kind: "tray" };
+      }
+      await sleep(100);
+    }
+    if (await hasLiveTrayClaim(options.dataRoot)) {
+      const error = new Error(TRAY_STARTING_MESSAGE);
+      error.code = "TRAY_CLAIMED";
+      throw error;
+    }
   }
   try {
     const session = await ensureInProcessSession(options);

--- a/integrations/deepseek-harness/test/agent.test.mjs
+++ b/integrations/deepseek-harness/test/agent.test.mjs
@@ -10,19 +10,26 @@ import {
   registerAgentSurfaces,
   runBgCommand,
 } from "../agent.mjs";
-import { stopInProcessSession } from "../host-apply.mjs";
+import { resolveApplyBackend, stopInProcessSession } from "../host-apply.mjs";
 import {
   CONTROL_FILE,
   CONTROL_SCHEMA,
   TRAY_MISSING_MESSAGE,
+  TRAY_STARTING_MESSAGE,
   callDshControl,
   inspectLocalMedia,
   isLoopbackControlUrl,
   matchSavedTheme,
   readDshControlFile,
+  readSessionHostFile,
+  readTrayClaim,
   removeDshControlFile,
+  removeSessionHostFile,
+  removeTrayClaim,
   stripPathQuotes,
   writeDshControlFile,
+  writeSessionHostFile,
+  writeTrayClaim,
 } from "../control-client.mjs";
 
 const TOKEN = "control-token-for-agent-tests-123456";
@@ -417,4 +424,65 @@ test("page bridge still loads when inject is absent", async (t) => {
   t.after(() => fs.rm(root, { recursive: true, force: true }));
   assert.ok(routes.has("/__beauticode/apply"));
   assert.ok(routes.has("/__beauticode/version"));
+});
+
+test("tray claim and session-host files ignore dead pids", async (t) => {
+  const root = await createTempRoot();
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await writeTrayClaim({ dataRoot: root, pid: process.pid });
+  const liveClaim = await readTrayClaim(root);
+  assert.equal(liveClaim.pid, process.pid);
+  await writeSessionHostFile({
+    dataRoot: root,
+    host: "dsh",
+    url: "http://127.0.0.1:9",
+    token: TOKEN,
+    pid: process.pid,
+  });
+  const liveHost = await readSessionHostFile(root);
+  assert.equal(liveHost.host, "dsh");
+  assert.equal(liveHost.pid, process.pid);
+  assert.equal(await removeTrayClaim({ dataRoot: root, pid: process.pid }), true);
+  assert.equal(await readTrayClaim(root), null);
+  assert.equal(await removeSessionHostFile({ dataRoot: root, pid: process.pid }), true);
+  assert.equal(await readSessionHostFile(root), null);
+});
+
+test("resolveApplyBackend waits for a tray claim to become a live tray", async (t) => {
+  const root = await createTempRoot();
+  const tray = await startFakeTray(async ({ url }, res) => {
+    if (url === "/health") {
+      json(res, 200, { ok: true });
+      return;
+    }
+    json(res, 404, { ok: false });
+  });
+  t.after(async () => {
+    await tray.close();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await writeTrayClaim({ dataRoot: root, pid: process.pid });
+  setTimeout(() => {
+    void writeControl(root, tray.url);
+  }, 150);
+  const backend = await resolveApplyBackend({
+    dataRoot: root,
+    baseUrl: "http://127.0.0.1:1",
+  });
+  assert.equal(backend.kind, "tray");
+});
+
+test("resolveApplyBackend refuses in-process start while a live tray claim remains", async (t) => {
+  const root = await createTempRoot();
+  t.after(async () => {
+    await stopInProcessSession(root);
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await writeTrayClaim({ dataRoot: root, pid: process.pid });
+  await assert.rejects(
+    () => resolveApplyBackend({ dataRoot: root, baseUrl: "http://127.0.0.1:1" }),
+    (error) => error.message === TRAY_STARTING_MESSAGE && error.code === "TRAY_CLAIMED",
+  );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beauticode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beauticode",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beauticode",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "description": "Local image/video backgrounds for DeepSeek Harness (also Codex Desktop). Unofficial.",

--- a/packages/adapter-dsh/src/session.ts
+++ b/packages/adapter-dsh/src/session.ts
@@ -16,6 +16,7 @@ import { DshHostApplier, normalizeDshBaseUrl } from "./bridge.js";
 import { DSH_HOST_DESCRIPTOR } from "./host-descriptor.js";
 import { acquireDshInjectorLock } from "./injector-lock.js";
 import { ensureBridgeToken } from "./token.js";
+import { trayHandoffRequested } from "./tray-handoff.js";
 
 export interface DshSessionOptions {
   baseUrl?: string;
@@ -24,6 +25,11 @@ export interface DshSessionOptions {
   pollMs?: number;
   onError?: (err: Error) => void;
   onStatus?: (msg: string) => void;
+  /**
+   * When true (plugin in-process session), stop if the tray claims the data
+   * root. The tray session-host must leave this false — it writes the claim.
+   */
+  honorTrayHandoff?: boolean;
 }
 
 export class DshSession implements HostSession {
@@ -32,6 +38,7 @@ export class DshSession implements HostSession {
   readonly dataRoot: string;
   readonly verifyDeadlineMs: number;
   readonly pollMs: number;
+  readonly honorTrayHandoff: boolean;
   readonly baseUrl: URL;
 
   private store: BackgroundStore;
@@ -39,6 +46,7 @@ export class DshSession implements HostSession {
   private host: DshHostApplier | null = null;
   private releaseLock: (() => Promise<void>) | null = null;
   private watchTimer: ReturnType<typeof setInterval> | null = null;
+  private handoffTimer: ReturnType<typeof setInterval> | null = null;
   private watchTask: Promise<void> | null = null;
   private stopTask: Promise<void> | null = null;
   private activeOperations = new Set<Promise<unknown>>();
@@ -59,6 +67,7 @@ export class DshSession implements HostSession {
     this.dataRoot = opts.dataRoot ?? defaultDataRoot();
     this.verifyDeadlineMs = opts.verifyDeadlineMs ?? 30_000;
     this.pollMs = opts.pollMs ?? 2_000;
+    this.honorTrayHandoff = opts.honorTrayHandoff !== false;
     this.baseUrl = normalizeDshBaseUrl(opts.baseUrl ?? "http://127.0.0.1:3080");
     this.store = new BackgroundStore({ root: this.dataRoot });
     this.media = new MediaServerController({
@@ -99,6 +108,10 @@ export class DshSession implements HostSession {
       throw error;
     }
     this.startWatchLoop();
+    if (this.honorTrayHandoff) {
+      this.startHandoffLoop();
+      void this.yieldToTrayIfRequested();
+    }
     void this.watchOnce();
     return { port: this.bridgePort() };
   }
@@ -416,6 +429,8 @@ export class DshSession implements HostSession {
     this.closed = true;
     if (this.watchTimer) clearInterval(this.watchTimer);
     this.watchTimer = null;
+    if (this.handoffTimer) clearInterval(this.handoffTimer);
+    this.handoffTimer = null;
     await Promise.allSettled(
       [this.watchTask, ...this.activeOperations].filter(
         (value): value is Promise<unknown> => Boolean(value),
@@ -445,6 +460,18 @@ export class DshSession implements HostSession {
   private startWatchLoop(): void {
     this.watchTimer = setInterval(() => void this.watchOnce(), this.pollMs);
     this.watchTimer.unref?.();
+  }
+
+  private startHandoffLoop(): void {
+    this.handoffTimer = setInterval(() => void this.yieldToTrayIfRequested(), 250);
+    this.handoffTimer.unref?.();
+  }
+
+  private async yieldToTrayIfRequested(): Promise<void> {
+    if (this.closed || this.stopTask) return;
+    if (!(await trayHandoffRequested(this.dataRoot))) return;
+    this.onStatus?.("beautiCode 托盘正在接管，正在释放本机会话。");
+    await this.stop();
   }
 
   private async watchOnce(): Promise<void> {

--- a/packages/adapter-dsh/src/tray-handoff.ts
+++ b/packages/adapter-dsh/src/tray-handoff.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export const TRAY_CLAIM_FILE = "tray-claim.json";
+export const TRAY_CLAIM_SCHEMA = "beauticode.tray-claim/v1";
+export const SESSION_HOST_FILE = "session-host.json";
+export const SESSION_HOST_SCHEMA = "beauticode.session-host/v1";
+export const DSH_CONTROL_FILE = "dsh-control.json";
+export const DSH_CONTROL_SCHEMA = "beauticode.dsh-control/v1";
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return Boolean(error && typeof error === "object" && "code" in error && error.code === "EPERM");
+  }
+}
+
+async function readLivePid(filePath: string, schema?: string): Promise<number | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { schema?: unknown; pid?: unknown };
+    if (schema && parsed.schema !== schema) return null;
+    const pid = Number(parsed.pid);
+    if (!Number.isInteger(pid) || pid <= 0 || !isPidAlive(pid)) return null;
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+/** True when the tray is starting or a different session-host owns the data root. */
+export async function trayHandoffRequested(
+  dataRoot: string,
+  selfPid: number = process.pid,
+): Promise<boolean> {
+  const root = path.resolve(dataRoot);
+  const claimPid = await readLivePid(path.join(root, TRAY_CLAIM_FILE), TRAY_CLAIM_SCHEMA);
+  // In-process sessions never write this file; any live claim means the tray wants the lock.
+  if (claimPid != null) return true;
+  const hostPid = await readLivePid(path.join(root, SESSION_HOST_FILE), SESSION_HOST_SCHEMA);
+  if (hostPid != null && hostPid !== selfPid) return true;
+  const controlPid = await readLivePid(path.join(root, DSH_CONTROL_FILE), DSH_CONTROL_SCHEMA);
+  return controlPid != null && controlPid !== selfPid;
+}

--- a/packages/adapter-dsh/test/adapter.test.js
+++ b/packages/adapter-dsh/test/adapter.test.js
@@ -280,6 +280,41 @@ test("DSH watch loop does not republish a matching generation while render ack i
   assert.equal(bridge.applyCount, applyCount);
 });
 
+test("DSH session yields the injector lock when the tray claims it", async (t) => {
+  const bridge = await mockBridge(null);
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "beauticode-dsh-yield-"));
+  const dataRoot = path.join(root, "data");
+  const session = new DshSession({
+    baseUrl: bridge.url,
+    dataRoot,
+    verifyDeadlineMs: 50,
+    pollMs: 60_000,
+  });
+  t.after(async () => {
+    await session.stop();
+    await bridge.close();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await session.start();
+  assert.equal(session.isOpen, true);
+  await fs.writeFile(
+    path.join(dataRoot, "tray-claim.json"),
+    `${JSON.stringify({
+      schema: "beauticode.tray-claim/v1",
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    })}\n`,
+  );
+  const deadline = Date.now() + 3_000;
+  while (session.isOpen && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.equal(session.isOpen, false);
+  await assert.rejects(() => fs.readFile(path.join(dataRoot, "injector.lock")), {
+    code: "ENOENT",
+  });
+});
+
 test("DSH session rolls disk state back when the bridge disappears", async (t) => {
   const bridge = await mockBridge(null);
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "beauticode-dsh-rollback-"));

--- a/packages/adapter-dsh/test/launcher-scripts.test.js
+++ b/packages/adapter-dsh/test/launcher-scripts.test.js
@@ -55,6 +55,90 @@ test("DSH runtime launcher and installer are gone", () => {
   );
 });
 
+test("tray lifecycle owns leftover session-host and second-click show-panel", () => {
+  const tray = fs.readFileSync(
+    path.join(repoRoot, "apps/tray/start-tray.ps1"),
+    "utf8",
+  );
+  const host = fs.readFileSync(
+    path.join(repoRoot, "apps/tray/session-host.mjs"),
+    "utf8",
+  );
+  assert.match(tray, /BeautiCodeJob/);
+  assert.match(tray, /JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE/);
+  assert.match(tray, /Stop-BcSessionHost/);
+  assert.match(tray, /Write-BcTrayClaim/);
+  assert.match(tray, /Use-BcAdoptedControl/);
+  assert.match(tray, /existing tray signaled to show panel/);
+  assert.match(tray, /--parent-pid/);
+  assert.doesNotMatch(tray, /\$pid\s*=/);
+  assert.match(host, /--parent-pid/);
+  assert.match(host, /writeSessionHostFile/);
+});
+
+test("README documents installer auto-wiring, npx, and custom install paths", () => {
+  const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+  assert.match(readme, /不需要安装 pnpm|也不需要安装 pnpm/);
+  assert.match(readme, /npx @deepseek-ai\/dsh web/);
+  assert.match(readme, /npx @deepseek-ai\/dsh plugin/);
+  assert.match(readme, /集成说明\.txt/);
+  assert.match(readme, /一般不需要再执行 `dsh plugin add`/);
+});
+
+test("install-dsh-plugin writes an integration note for the actual install root", () => {
+  const script = path.join(repoRoot, "scripts/install-dsh-plugin.ps1");
+  const pluginRoot = path.join(repoRoot, "integrations/deepseek-harness");
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "bc-dsh-home-"));
+  const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bc-install-"));
+  try {
+    const add = spawnSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        script,
+        "-PluginRoot",
+        pluginRoot,
+        "-DshHome",
+        home,
+        "-InstallRoot",
+        installRoot,
+      ],
+      { encoding: "utf8", windowsHide: true },
+    );
+    assert.equal(add.status, 0, add.stderr || add.stdout);
+    const note = fs.readFileSync(path.join(installRoot, "集成说明.txt"), "utf8");
+    assert.match(note, /不需要安装 pnpm/);
+    assert.match(note, /npx @deepseek-ai\/dsh web/);
+    assert.match(note, new RegExp(installRoot.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")));
+    const remove = spawnSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        script,
+        "-PluginRoot",
+        pluginRoot,
+        "-DshHome",
+        home,
+        "-InstallRoot",
+        installRoot,
+        "-Remove",
+      ],
+      { encoding: "utf8", windowsHide: true },
+    );
+    assert.equal(remove.status, 0, remove.stderr || remove.stdout);
+    assert.equal(fs.existsSync(path.join(installRoot, "集成说明.txt")), false);
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(installRoot, { recursive: true, force: true });
+  }
+});
+
 test("picker and tray never spawn a DSH process", () => {
   const picker = fs.readFileSync(
     path.join(repoRoot, "scripts/start-beauticode.ps1"),
@@ -79,6 +163,7 @@ test("picker and tray never spawn a DSH process", () => {
   assert.match(installer, /agent\.mjs/);
   assert.match(installer, /control-client\.mjs/);
   assert.match(installer, /host-apply\.mjs/);
+  assert.match(installer, /integration-note\.zh\.txt/);
 });
 
 test("picker DryRun routes DSH to the tray and Codex to its launcher", () => {

--- a/packages/adapter-dsh/test/session-host.test.js
+++ b/packages/adapter-dsh/test/session-host.test.js
@@ -71,6 +71,19 @@ test("session-host starts in DSH mode without touching Codex", async (t) => {
   const health = await healthResponse.json();
   assert.equal(health.host.kind, "dsh");
   assert.equal(health.port, null);
+  assert.equal(health.open, true);
+
+  await fs.writeFile(
+    path.join(root, "data", "tray-claim.json"),
+    `${JSON.stringify({
+      schema: "beauticode.tray-claim/v1",
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+    })}\n`,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  const stillOpen = await fetch(`http://127.0.0.1:${ready.controlPort}/health`, { headers });
+  assert.equal((await stillOpen.json()).open, true);
 
   const controlFile = path.join(root, "data", "dsh-control.json");
   const advertised = JSON.parse(await fs.readFile(controlFile, "utf8"));
@@ -79,6 +92,14 @@ test("session-host starts in DSH mode without touching Codex", async (t) => {
   assert.equal(advertised.url, `http://127.0.0.1:${ready.controlPort}`);
   assert.equal(advertised.token, CONTROL_TOKEN);
   assert.equal(advertised.pid, child.pid);
+
+  const hostFile = path.join(root, "data", "session-host.json");
+  const advertisedHost = JSON.parse(await fs.readFile(hostFile, "utf8"));
+  assert.equal(advertisedHost.schema, "beauticode.session-host/v1");
+  assert.equal(advertisedHost.host, "dsh");
+  assert.equal(advertisedHost.url, `http://127.0.0.1:${ready.controlPort}`);
+  assert.equal(advertisedHost.token, CONTROL_TOKEN);
+  assert.equal(advertisedHost.pid, child.pid);
 
   const shutdown = await fetch(`http://127.0.0.1:${ready.controlPort}/shutdown`, {
     method: "POST",
@@ -89,4 +110,74 @@ test("session-host starts in DSH mode without touching Codex", async (t) => {
   await new Promise((resolve) => child.once("exit", resolve));
   assert.equal(child.exitCode, 0, stderr);
   await assert.rejects(() => fs.readFile(controlFile), { code: "ENOENT" });
+  await assert.rejects(() => fs.readFile(hostFile), { code: "ENOENT" });
+});
+
+test("session-host exits when its parent pid dies", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "beauticode-dsh-parent-"));
+  const parent = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    stdio: "ignore",
+  });
+  const child = spawn(
+    process.execPath,
+    [
+      hostScript,
+      "--host",
+      "dsh",
+      "--dsh-url",
+      "http://127.0.0.1:1",
+      "--data-root",
+      path.join(root, "data"),
+      "--verify-ms",
+      "20",
+      "--parent-pid",
+      String(parent.pid),
+    ],
+    {
+      cwd: path.resolve(here, "../../.."),
+      env: { ...process.env, BEAUTICODE_CONTROL_TOKEN: CONTROL_TOKEN },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  t.after(async () => {
+    if (parent.exitCode == null) parent.kill();
+    if (child.exitCode == null) child.kill();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`ready timeout: ${stderr}`)), 5_000);
+    const lines = readline.createInterface({ input: child.stdout });
+    lines.on("line", (line) => {
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed.ready) {
+          clearTimeout(timer);
+          lines.close();
+          resolve(parsed);
+        }
+      } catch {
+        /* ignore */
+      }
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`session-host exited ${code} before ready: ${stderr}`));
+    });
+  });
+
+  parent.kill();
+  const exitCode = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`parent-watch timeout: ${stderr}`)), 5_000);
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+  assert.equal(exitCode, 0, stderr);
 });

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -94,6 +94,10 @@ export async function ensureDataLayout(paths: DataPaths): Promise<void> {
       entry === "engine-launcher.log" ||
       entry === "injector.lock" ||
       entry === "store.lock" ||
+      entry === "dsh-control.json" ||
+      entry === "session-host.json" ||
+      entry === "tray-claim.json" ||
+      entry === "dsh-bridge.token" ||
       entry === ".beauticode-commit.json" ||
       entry === ".beauticode-commit-in-progress" ||
       entry.startsWith("active-backup-");

--- a/scripts/build-windows-installer.ps1
+++ b/scripts/build-windows-installer.ps1
@@ -226,6 +226,7 @@ foreach ($relativeFile in @(
     "scripts\start-beauticode.ps1",
     "scripts\start-beauticode-engine.ps1",
     "scripts\install-dsh-plugin.ps1",
+    "scripts\integration-note.zh.txt",
     "packages\core\package.json",
     "packages\adapter-codex\package.json",
     "packages\adapter-dsh\package.json",

--- a/scripts/install-dsh-plugin.ps1
+++ b/scripts/install-dsh-plugin.ps1
@@ -13,6 +13,7 @@
 param(
   [string]$PluginRoot = "",
   [string]$DshHome = "",
+  [string]$InstallRoot = "",
   [switch]$Remove
 )
 
@@ -192,6 +193,25 @@ function Ensure-WebPackageDep {
   [IO.File]::WriteAllText($webPackage, ($text.TrimEnd() + "`n"), $utf8)
 }
 
+function Get-BcIntegrationNoteName {
+  # 集成说明.txt — built from code points so this ASCII script stays PS 5.1-safe.
+  return ((-join @(0x96C6, 0x6210, 0x8BF4, 0x660E | ForEach-Object { [char]$_ })) + ".txt")
+}
+
+function Write-IntegrationNote([string]$Root) {
+  if (-not $Root) { return }
+  $installRoot = [IO.Path]::GetFullPath($Root)
+  $pluginPath = Join-Path $installRoot "integrations\deepseek-harness"
+  $template = Join-Path $scriptDir "integration-note.zh.txt"
+  if (-not (Test-Path -LiteralPath $template -PathType Leaf)) {
+    throw ("missing integration note template: {0}" -f $template)
+  }
+  $text = [IO.File]::ReadAllText($template)
+  $text = $text.Replace("{INSTALL_ROOT}", $installRoot).Replace("{PLUGIN_PATH}", $pluginPath)
+  $utf8 = New-Object System.Text.UTF8Encoding $false
+  [IO.File]::WriteAllText((Join-Path $installRoot (Get-BcIntegrationNoteName)), $text, $utf8)
+}
+
 if (-not (Test-Path -LiteralPath $indexFile -PathType Leaf)) {
   throw ("缺少 DSH 插件入口：{0}" -f $indexFile)
 }
@@ -210,6 +230,12 @@ if ($Remove) {
   }
   if ($removed) { Write-BcLog "Removed beautiCode DSH plugin wiring." }
   else { Write-BcLog "No beautiCode DSH plugin wiring to remove." }
+  if ($InstallRoot) {
+    $note = Join-Path ([IO.Path]::GetFullPath($InstallRoot)) (Get-BcIntegrationNoteName)
+    if (Test-Path -LiteralPath $note -PathType Leaf) {
+      Remove-Item -LiteralPath $note -Force
+    }
+  }
   exit 0
 }
 
@@ -233,6 +259,15 @@ if ($webExists) {
   }
   Write-BridgePatch $homePatch (Get-FileUriInsert $fileUri)
   Write-BcLog ("DSH web profile not found; wrote home patch $homePatch")
+}
+
+if ($InstallRoot) {
+  try {
+    Write-IntegrationNote $InstallRoot
+    Write-BcLog ("Wrote integration note to {0}" -f ([IO.Path]::GetFullPath($InstallRoot)))
+  } catch {
+    Write-BcLog ("Failed to write integration note: {0}" -f $_.Exception.Message)
+  }
 }
 
 exit 0

--- a/scripts/integration-note.zh.txt
+++ b/scripts/integration-note.zh.txt
@@ -1,0 +1,22 @@
+beautiCode 集成说明
+
+安装目录：
+{INSTALL_ROOT}
+
+安装包已经自动把插件写入 DeepSeek Harness。
+一般不需要再执行 dsh plugin add，也不需要安装 pnpm。
+
+自己启动 DeepSeek Harness：
+  dsh web
+  或 npx @deepseek-ai/dsh web
+
+若自动写入失败，再手动安装插件（路径已按本次安装目录填好）：
+
+已全局安装 dsh：
+  dsh plugin --profile web add file:{PLUGIN_PATH}
+
+只用 npx：
+  npx @deepseek-ai/dsh plugin --profile web add file:{PLUGIN_PATH}
+
+dsh plugin add 需要本机有 pnpm。安装包自动写入不需要 pnpm。
+若安装时改过目录，请使用上面的实际路径，不要照抄 %LOCALAPPDATA%\Programs\beautiCode。


### PR DESCRIPTION
## 背景

飞哥在 v1.0.0 上测到二次启动 `session-host exited early (1)`、托盘图标没了但 `node.exe` 还在，以及 README 的 `dsh plugin add` 依赖 pnpm、写死默认路径、假定 `dsh` 已全局安装。

根因不是固定端口 50067。session-host 本来就是 `listen(0)`。真正的死循环是：托盘进程没了，孙子进程 `node` 还占着 `injector.lock`，再点快捷方式就会抢锁失败。

## 改动

- 用 Job Object（`KILL_ON_JOB_CLOSE`）把 session-host 绑到托盘上，并加 `--parent-pid` 看守
- 启动失败 / trap / 退出都走同一套收尸
- 残留控制面 `/health` 通就接管，不通且持有者是 `session-host.mjs` 才杀掉（不杀 DSH）
- 二次点击发 ShowPanel，不再静默 `exit 0`
- 插件进程内 session 看到托盘认领会让出锁；托盘自己的 session-host **不**响应自己写的 claim
- README / 集成文档补上：安装包自动写入、不需要 pnpm、`npx` 写法、自定义目录看 `集成说明.txt`
- 版本保持 **v1.0.0**。新安装包已替换 GitHub Release 上的 `beautiCode-Setup-1.0.0-win-x64.exe`

## 本机快捷方式验证

按安装包同一条命令启动（Hidden + `start-beauticode.ps1`）：

- 首次启动：`session-host ready`，`/health open=true`，注入锁存在
- 再点一次：`show-panel event received`，PID 不变，没有新 session-host
- 只杀托盘 PowerShell：session-host 约 300ms 内退出，无残留
- 再启动：重新 ready，不再 `exited early`
- 快捷方式弹出选择框，状态为「已连接 DeepSeek Harness / 当前」

验证中还修了两个现场 bug：PowerShell 不能给只读自动变量 `$PID` 赋值；托盘自己的 claim 不能让 session-host 自杀。

## 测试

`npm test` 通过。